### PR TITLE
DCP2-393 Remove show more/less toggle from repository cards

### DIFF
--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -25,7 +25,7 @@
         <%= link_to_unless(params[:id] == repository.slug, repository.name, repository_collections_path(repository)) %>
       </h2>
 
-      <p class="card-text" data-arclight-truncate="true">
+      <p class="card-text" data-arclight-truncate="false">
         <%= repository.description %>
       </p>
 
@@ -59,7 +59,7 @@
       <h2 class="card-title page-sub-sub-heading">
         <%= link_to_unless(params[:id] == repository.slug, repository.name, repository_collections_path(repository)) %>
       </h2>
-      <p class="card-text" data-arclight-truncate="true">
+      <p class="card-text" data-arclight-truncate="false">
         <%= link_to_unless(params[:id] == repository.slug, "See More About This Repository", repository_collections_path(repository)) %>
       </p>
     </div>


### PR DESCRIPTION
## What's new

Remove show more/show less toggle from repository card. [DCP2-383](https://mlit.atlassian.net/browse/DCP2-393)
[http://localhost:3000/repositories](http://localhost:3000/repositories)

Chris may need to update the summaries after.
<img width="800" alt="" src="https://user-images.githubusercontent.com/29953622/212122001-72b4304a-1e76-4b25-8496-91fc203447f5.png">


[DCP2-383]: https://mlit.atlassian.net/browse/DCP2-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ