### PR TITLE
DCP2-394 DCP2-395 Remove alt text and repetitive links

### DIFF
--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -7,20 +7,10 @@
 <%# renders as card display %>
 
   <div class="card al-repository">
-
     <div class="card-img-top">
-      <% if (params[:id] != repository.slug) %>
-        <%= link_to(repository_collections_path(repository)) do %>
-          <%= image_tag repository.thumbnail_url, alt: repository.name, class: 'card-img' %>
-        <% end %>
-      <% else %>
-        <%= image_tag repository.thumbnail_url, alt: repository.name, class: 'card-img' %>
-      <% end %>
+     <%= image_tag repository.thumbnail_url, alt: '', class: 'card-img' %>
     </div>
-    
-
     <div class="card-body">
-
       <h2 class="card-title text-center">
         <%= link_to_unless(params[:id] == repository.slug, repository.name, repository_collections_path(repository)) %>
       </h2>
@@ -32,15 +22,12 @@
     </div>
 
     <div class="card-footer">
-      
        <div class="collection-count-wrapper text-center">
         <%= link_to(repository_collections_path(repository), class: 'btn btn-primary')  do %>
           <%= t('arclight.views.repositories.browse') %> <%= t(:'arclight.views.repositories.number_of_collections', count: repository.collection_count) %>
         <% end %>
       </div>
-
     </div>
-
   </div>
 
 
@@ -51,7 +38,7 @@
 
     <div class="card-img">
       <div class="img-wrapper">
-        <%= image_tag repository.thumbnail_url, alt: repository.name, class: 'card-img' %>
+        <%= image_tag repository.thumbnail_url, alt: '', class: 'card-img' %>
       </div>
     </div>
 


### PR DESCRIPTION
## What's new

Issue: repetitive links for a card, decorative img with alt text, and no visual focus on img link. Repository cards had 4 links (focus stops) per card (Image, heading, show more/less truncator, and browse button). We have removed the truncator, so there were still 3 links per card.

- Removed link from card image and made decorative`alt: ''`

Note: Normally we would want the entire card to be 1 link but the `repository.description` is too long and screen readers will read the entire link, so settling on two links per card (heading and browse) for now.

This satisfies [DCP2-394](https://mlit.atlassian.net/browse/DCP2-394) and [DCP2-395](https://mlit.atlassian.net/browse/DCP2-395)

[DCP2-394]: https://mlit.atlassian.net/browse/DCP2-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCP2-395]: https://mlit.atlassian.net/browse/DCP2-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ