### PR TITLE
DCP2-391 Update toggle buttons for accessibility

### DIFF
--- a/app/assets/stylesheets/dul-arclight/dul_styles.scss
+++ b/app/assets/stylesheets/dul-arclight/dul_styles.scss
@@ -708,6 +708,36 @@ label.toggle-bookmark > span:nth-child(2) {
       padding: 0.25rem 0.5rem;
       font-size: 14px;
     }
+
+    .btn-outline-secondary {
+      background-color: #fff;
+      border: solid 1px var(--color-neutral-400);
+      color: var(--color-neutral-400);
+      padding: 0.5rem;
+    }
+
+    .btn-outline-secondary:not(:disabled):not(.disabled).active {
+      background-color: var(--color-teal-100);
+      border: solid 1px var(--color-teal-400);
+      color: var(--color-teal-400);
+    }
+
+    .btn-outline-secondary:not(:disabled):not(.disabled).active:before {
+      font-family: "Font Awesome 5 Free";
+      font-weight: 900;
+      content: "\f00c";
+      margin-right: 0.35rem;
+      display: inline-block;
+      text-decoration: none;
+    }
+
+    .btn-outline-secondary:hover {
+      background-color: var(--color-neutral-100);
+    }
+  }
+
+  .pagination {
+    padding-bottom: .5rem;
   }
 
   .al-grouped-results .al-grouped-title-bar {
@@ -983,19 +1013,6 @@ label.toggle-bookmark > span:nth-child(2) {
     line-height: 1.2;
     .al-repository-street-address {
       margin-bottom: 1rem;
-    }
-  }
-}
-
-.card-text,
-.al-grouped-title-bar {
-  .responsiveTruncatorToggle {
-    &::before {
-      background: linear-gradient(
-        to left,
-        $facet-grey,
-        rgba(255, 255, 255, 0.1)
-      );
     }
   }
 }

--- a/app/views/catalog/_group_toggle.html.erb
+++ b/app/views/catalog/_group_toggle.html.erb
@@ -1,0 +1,12 @@
+<div class="result-type-group mb-2 mb-lg-0 btn-group float-lg-left float-md-right" role="group" aria-label="<%= t('arclight.views.index.group_results') %>">
+  <%= link_to t('arclight.views.index.all_results'),
+              search_catalog_path(search_without_group),
+              class: "btn btn-outline-secondary #{'active' unless grouped?}",
+              'aria-label': "All Results #{'selected' unless grouped?}"
+  %>
+  <%= link_to t('arclight.views.index.group_by_collection'),
+              search_catalog_path(search_with_group),
+              class: "btn btn-outline-secondary #{'active' if grouped?}", 
+              'aria-label': "Grouped by collection #{'selected' if grouped?}"
+  %>
+</div>


### PR DESCRIPTION
## What's new
Issue: Toggle buttons only visually indicated the active state of the toggle. 

- Add partial for toggle from Arclight
- Add aria-label conditionally for the link that is active
- Re-styled secondary outline buttons with Design System styles and added an icon to clearly show which toggle is active and add some padding

**Proposed changes**
<img width="886" alt="" src="https://user-images.githubusercontent.com/29953622/214665173-f63e3d7b-55b5-4ceb-8c44-a75c7e53d8ac.png">

**In production currently**
<img width="904" alt="" src="https://user-images.githubusercontent.com/29953622/214665105-da8754bd-d992-4b27-9d79-bc68880a20e7.png">


Resolves [DCP2-391](https://mlit.atlassian.net/browse/DCP2-391)



[DCP2-391]: https://mlit.atlassian.net/browse/DCP2-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ