### PR TITLE
DCP2-322 - download xml

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -11,8 +11,6 @@ class CatalogController < ApplicationController
   include DulArclight::FieldConfigHelpers
   include HierarchyHelper
 
-  helper_method :pdf_available?
-
   # DUL CUSTOMIZATION: temporary patch for
   # ArcLight bug https://github.com/projectblacklight/arclight/issues/741
   # Patched for now by copying the raw method from Blacklight https://github.com/projectblacklight/blacklight/blob/master/app/controllers/concerns/blacklight/catalog.rb#L57-L63

--- a/app/models/arclight/requests/aeon_web_ead.rb
+++ b/app/models/arclight/requests/aeon_web_ead.rb
@@ -28,7 +28,7 @@ module Arclight
       end
 
       def parsed_ead_url
-        return ead_url unless document.repository_config.request_id_present?
+        return ead_url unless document.repository_config.request_prefix_present?
 
         field = document.repository_config.request_field
         pattern = document.repository_config.request_pattern

--- a/app/models/concerns/dul_arclight/catalog.rb
+++ b/app/models/concerns/dul_arclight/catalog.rb
@@ -28,7 +28,7 @@ module DulArclight
     # https://github.com/projectblacklight/blacklight/blob/master/app/controllers/concerns/blacklight/catalog.rb#L65-L71
     def ead_download
       xml_filename = download_helper.ead_file_path
-      
+
       if xml_filename.nil?
         render plain: '404 Not Found', status: :not_found
         return
@@ -65,7 +65,6 @@ module DulArclight
     end
 
     def pdf_download
-
       send_file(
         download_helper.pdf_file_path,
         filename: "#{@document.id}.pdf",

--- a/app/models/concerns/dul_arclight/solr_document.rb
+++ b/app/models/concerns/dul_arclight/solr_document.rb
@@ -37,6 +37,10 @@ module Arclight
       repository_config&.slug
     end
 
+    def publicid
+      fetch('publicid_ssi', nil)&.strip
+    end
+
     def request_field(field)
       fetch(field, nil)&.strip
     end

--- a/app/views/arclight/requests/_aeon_web_ead.html.erb
+++ b/app/views/arclight/requests/_aeon_web_ead.html.erb
@@ -3,5 +3,5 @@
   <% ead_url = File.join(root_url, 'catalog', document.id.gsub('.', '-'), 'xml') %>
   <% aeon_web_ead ||= Arclight::Requests::AeonWebEad.new(document, ead_url) %>
   <% aeon_web_ead_url = aeon_web_ead&.url %>
-  <%= link_to 'Request', aeon_web_ead_url, class: 'btn btn-secondary btn-sm', target:'_blank' %>
+  <%= link_to 'Request', aeon_web_ead_url, class: 'btn btn-primary btn-sm', target:'_blank' %>
 <% end %>

--- a/app/views/arclight/requests/_aeon_web_ead.html.erb
+++ b/app/views/arclight/requests/_aeon_web_ead.html.erb
@@ -1,7 +1,7 @@
 <% document ||= @document %>
-<% if parsed_files = ead_files(document) %>
-  <% aeon_web_ead ||= Arclight::Requests::AeonWebEad.new(document, parsed_files.href) %>
+<% if UmArclight::DownloadHelper.new(document).ead_available? %>
+  <% ead_url = File.join(root_url, 'catalog', document.id.gsub('.', '-'), 'xml') %>
+  <% aeon_web_ead ||= Arclight::Requests::AeonWebEad.new(document, ead_url) %>
   <% aeon_web_ead_url = aeon_web_ead&.url %>
-
   <%= link_to 'Request', aeon_web_ead_url, class: 'btn btn-secondary btn-sm', target:'_blank' %>
 <% end %>

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -83,7 +83,6 @@ scrc:
   request_id:
     field: 'publicid_ssi'
     pattern: '-\/\/us::MiU\/\/TEXT us::MiU::(.*)\/\/EN'
-    prefix: 'https://quod.lib.umich.edu/s/sclead/eads/'
   dlxs_iiif:
     image:
       - scl
@@ -126,7 +125,6 @@ clements:
   request_id:
     field: 'publicid_ssi'
     pattern: 'us//::miu-c//TXT us::miu-c::(.*.xml)\/\/EN'
-    prefix: 'https://quod.lib.umich.edu/c/clementsead/eads/'
   dlxs_iiif:
     image:
       - pohrt

--- a/lib/um_arclight/download_helper.rb
+++ b/lib/um_arclight/download_helper.rb
@@ -1,0 +1,54 @@
+module UmArclight
+  class DownloadHelper
+    attr_accessor :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def ead_file_path
+      # look for the document eadid first
+      filename = File.join(DulArclight.finding_aid_data, 'ead', repo_id, "#{eadid}.xml")
+      return filename if File.exist?(filename)
+      
+      return ead_filename_from_publicid if request_pattern_present?
+    end
+
+    def html_file_path
+      File.join(DulArclight.finding_aid_data, 'pdf', repo_id, "#{eadid}.html")
+    end
+
+    def pdf_file_path
+      File.join(DulArclight.finding_aid_data, 'pdf', repo_id, "#{eadid}.pdf")
+    end
+
+    def ead_filename_from_publicid
+      # look for a filename based on publicid_ssi + request_pattern
+      publicid = document.publicid
+      request_pattern = document.repository_config.request_pattern
+      match = Regexp.new(request_pattern).match(publicid)
+      filename = File.join(DulArclight.finding_aid_data, 'ead', repo_id, match[1])
+      return filename if File.exist?(filename)
+    end
+
+    def repo_id
+      document.repository_config&.slug
+    end
+
+    def eadid
+      document.eadid
+    end
+
+    def request_pattern_present?
+      document.repository_config&.request_pattern_present?
+    end
+
+    def ead_available?
+      File.exist?(ead_file_path)
+    end
+
+    def pdf_available?
+      File.exist?(pdf_file_path)
+    end
+  end
+end

--- a/lib/um_arclight/download_helper.rb
+++ b/lib/um_arclight/download_helper.rb
@@ -10,7 +10,7 @@ module UmArclight
       # look for the document eadid first
       filename = File.join(DulArclight.finding_aid_data, 'ead', repo_id, "#{eadid}.xml")
       return filename if File.exist?(filename)
-      
+
       return ead_filename_from_publicid if request_pattern_present?
     end
 
@@ -35,9 +35,7 @@ module UmArclight
       document.repository_config&.slug
     end
 
-    def eadid
-      document.eadid
-    end
+    delegate :eadid, to: :document
 
     def request_pattern_present?
       document.repository_config&.request_pattern_present?

--- a/spec/models/arclight/requests/aeon_web_ead_spec.rb
+++ b/spec/models/arclight/requests/aeon_web_ead_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Arclight::Requests::AeonWebEad do
     end
 
     it 'responds to parsed_ead_url' do
-      expect(valid_object.parsed_ead_url).to eq 'https://quod.lib.umich.edu/s/sclead/eads/ams0099.xml'
+      # expect(valid_object.parsed_ead_url).to eq 'https://quod.lib.umich.edu/s/sclead/eads/ams0099.xml'
+      expect(valid_object.parsed_ead_url).to eq 'http://example.com/sample.xml'
     end
   end
 end


### PR DESCRIPTION
Fixing the `/xml` route to look for an EAD XML file based on `publicid`? Piece of cake.

Fixing the aeon download helper to use this information? Madness. I'm still not 100% sure how `downloads.yml` is really supposed to work or be used. ¯\_(ツ)_/¯ 