### PR TITLE
DCP2-250-ish - address uninteresting children in sidebar navigation

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -168,7 +168,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   end
 
   def is_linkable?
-    !(total_digital_object_count == 0 && number_of_children == 0)
+    (online_content? || number_of_children > 0)
   end
 
   # DUL override ArcLight core; we want all extent values, and to singularize e.g. 1 boxes.

--- a/app/views/catalog/_index_child_components_nestable.html.erb
+++ b/app/views/catalog/_index_child_components_nestable.html.erb
@@ -52,7 +52,12 @@
         <% if document.is_linkable? %>
           <%= link_to_document(document, document_show_link_field(document), { counter: counter }, { anchor: "contents" }) %>
         <% else %>
-          <span><%= index_presenter(document).label %></span>
+          <span>
+            <%= index_presenter(document).label %>
+            <span> / <%= document.number_of_children %></span>
+            <span> / <%= document.total_digital_object_count %></span>
+            <span> / <%= document.online_content? %></span>
+          </span>
         <% end %>
         <% if document.children? %>
           <span class="badge badge-pill badge-secondary al-number-of-children-badge"><%= document.number_of_children %> <%= t(:'um_arclight.views.index.number_of_components', count: document.number_of_children) %></span>

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -41,16 +41,20 @@
 
         <% counter = document_counter_with_offset(document_counter) %>
         <!-- def link_to_document(doc, field_or_opts = nil, opts = { counter: nil }, url_options = { anchor: nil })-->
-        <%= link_to_document document, document_show_link_field(document),
-          {
-            class: 'tree-nav-leaf', title: document.level, counter: counter,
-            data: {
-              toggle: 'popover',
-              content: [document.containers.join(', '), document.short_description].reject(&:blank?).join('<br/>')
-            }
-          },
-          { anchor: "contents" }
-        %>
+        <% if document.is_linkable? %>
+          <%= link_to_document document, document_show_link_field(document),
+            {
+              class: 'tree-nav-leaf', title: document.level, counter: counter,
+              data: {
+                toggle: 'popover',
+                content: [document.containers.join(', '), document.short_description].reject(&:blank?).join('<br/>')
+              }
+            },
+            { anchor: "contents" }
+          %>
+        <% else %>
+          <span><%= index_presenter(document).label %></span>
+        <% end %>
 
         <%# ---------------------- %>
         <%# DESCENDANT COUNT BADGE %>


### PR DESCRIPTION
Renders uninteresting children as spans instead of links in the sidebar navigation. Brings it sync with the rendering of these in the contents list.

<img width="364" alt="image" src="https://user-images.githubusercontent.com/537867/216403447-1493bf04-435e-4bbc-89bf-68172d9dc77d.png">
