### PR TITLE
expand is_linkable? to include restricted_component?

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -168,7 +168,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   end
 
   def is_linkable?
-    (online_content? || number_of_children > 0)
+    (online_content? || number_of_children > 0 || restricted_component?)
   end
 
   # DUL override ArcLight core; we want all extent values, and to singularize e.g. 1 boxes.


### PR DESCRIPTION
Without this you can't open restricted items and view the access message.