### PR TITLE
DCP2-250 - base interesting-ness on blacklight_config.component_fields

### DIFF
--- a/app/helpers/um_arclight_helper.rb
+++ b/app/helpers/um_arclight_helper.rb
@@ -64,4 +64,11 @@ module UmArclightHelper
     title.unshift prefix if add_prefix
     _title = title.join(' ')
   end
+
+  SKIPPABLE_KEYS = ['containers', 'physdesc_tesim', 'creators_ssim', 'abstract_teism', 'scopecontent_tesim']
+  def is_interesting_component?(document)
+    (blacklight_config.component_fields.keys.find do |key|
+      (SKIPPABLE_KEYS.exclude?(key) && document.fetch(key, nil).present?)
+    end) || document.is_linkable?
+  end
 end

--- a/app/views/catalog/_index_child_components_nestable.html.erb
+++ b/app/views/catalog/_index_child_components_nestable.html.erb
@@ -49,7 +49,7 @@
     <div class="d-flex" xclass="documentHeader d-flex order-1" data-document-id="<%= document.id %>">
       <h3 xclass="index_title document-title-heading">
         <!-- def link_to_document(doc, field_or_opts = nil, opts = { counter: nil }, url_options = { anchor: nil })-->
-        <% if document.is_linkable? %>
+        <% if (is_interesting_component?(document)) %>
           <%= link_to_document(document, document_show_link_field(document), { counter: counter }, { anchor: "contents" }) %>
         <% else %>
           <span>

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -41,7 +41,7 @@
 
         <% counter = document_counter_with_offset(document_counter) %>
         <!-- def link_to_document(doc, field_or_opts = nil, opts = { counter: nil }, url_options = { anchor: nil })-->
-        <% if document.is_linkable? %>
+        <% if is_interesting_component?(document) %>
           <%= link_to_document document, document_show_link_field(document),
             {
               class: 'tree-nav-leaf', title: document.level, counter: counter,


### PR DESCRIPTION
So far interesting-ness has been defined by

- digital objects
- number of children
- restricted access

This update adds whether any of the `blacklight_config.component_fields` are present, to catch components that have `processinfo` defined. 