### PR TITLE
Enable Solr's updateHandler

### DIFF
--- a/solr/arclight/conf/solrconfig.xml
+++ b/solr/arclight/conf/solrconfig.xml
@@ -77,6 +77,19 @@
     </lst>
   </requestHandler>
 
+   <updateHandler class="solr.DirectUpdateHandler2">
+
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+
+    <autoCommit>
+      <maxTime>15000</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+
+  </updateHandler>
+
   <!-- config for the admin interface -->
   <admin>
     <defaultQuery>*:*</defaultQuery>


### PR DESCRIPTION
SolrCloud depends on the updateLog to conduct recovery for a replica, even when it has the complete index.