### PR TITLE
DCP2-519 - add x-robots-tag unless params[:id]

### DIFF
--- a/app/models/concerns/dul_arclight/catalog.rb
+++ b/app/models/concerns/dul_arclight/catalog.rb
@@ -23,6 +23,10 @@ module DulArclight
         helper_method :pdf_available?
         helper_method :ead_available?
       end
+
+      if respond_to?(:after_action)
+        after_action :add_noindex_headers
+      end
     end
 
     # DUL CUSTOMIZATION: send the source EAD XML file that we already have on the filesystem
@@ -83,6 +87,12 @@ module DulArclight
     def ead_available?(document)
       setup_download_helper
       download_helper.ead_available?
+    end
+
+    def add_noindex_headers
+      unless params[:id]
+        response.headers['X-Robots-Tag'] = 'noindex'
+      end
     end
 
     ##


### PR DESCRIPTION
We're mostly interesting in preventing all the search results from getting cached in search engines; this sends a `X-Robots-Tag: noindex` for any page that doesn't have an `:id` match on the route.

Reference: https://developers.google.com/search/docs/crawling-indexing/block-indexing#http-response-header