### PR TITLE
DCP2-522 - make did/note available to components

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -37,7 +37,8 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
-      rows: 10
+      rows: 10,
+      fl: '*'
     }
 
     # solr path which will be added to solr base url before the other solr params.
@@ -478,6 +479,7 @@ class CatalogController < ApplicationController
     config.add_component_field 'accruals_tesim', label: 'Accruals', helper_method: :render_html_tags
     config.add_component_field 'physloc_tesim', label: 'Physical Location', helper_method: :render_html_tags
     config.add_component_field 'materialspec_tesim', label: 'Material Specific Details', helper_method: :render_html_tags
+    config.add_component_field 'note_tesim', label: 'Note', helper_method: :render_html_tags
     config.add_component_field 'odd_tesim', label: 'Other Descriptive Data', helper_method: :render_html_tags
     config.add_component_field 'unitid_ssm', label: 'Unit ID', helper_method: :render_html_tags
 

--- a/lib/dul_arclight/traject/ead2_config.rb
+++ b/lib/dul_arclight/traject/ead2_config.rb
@@ -63,6 +63,7 @@ DID_SEARCHABLE_NOTES_FIELDS = %w[
   abstract
   materialspec
   physloc
+  note
 ].freeze
 
 # DUL CUSTOMIZATION: separated from SEARCHABLE_NOTES for more
@@ -756,7 +757,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     to_field "#{selector}_tesim", extract_xpath("./did/#{selector}", to_text: false)
     to_field "#{selector}_teim", extract_xpath("./did/#{selector}/*[local-name()!='head']")
   end
-  to_field 'did_note_ssm', extract_xpath('./did/note')
+  to_field 'did_note_teim', extract_xpath('./did/note')
 
   # DUL CUSTOMIZATION: add index
   to_field 'indexes_tesim', extract_xpath('./index', to_text: false)


### PR DESCRIPTION
- in `ead2_config.rb`
  - add 'note' to `DID_SEARCHABLE_NOTES_FIELDS`
  - rename `did_note_ssm` to `did_note_tesim`, which will get its contents copied to `text`
- add `fl: *` to `config.default_solr_params` so all the stored fields are available to actions/templates
- add `note_tesim` to the`config.add_component_field` block
