### PR TITLE
DCP2-435 - add 404 and 500 pages

### DIFF
--- a/app/assets/stylesheets/dul-arclight/modules/banners.scss
+++ b/app/assets/stylesheets/dul-arclight/modules/banners.scss
@@ -176,3 +176,7 @@
     color: tint($brand-primary, 80);
   }
 }
+
+.flash_messages > .alert:first-child {
+  margin-top: 0.5rem;
+}

--- a/app/assets/stylesheets/dul-arclight/modules/banners.scss
+++ b/app/assets/stylesheets/dul-arclight/modules/banners.scss
@@ -162,7 +162,7 @@
   }
 }
 
-.alert-info {
+.alert-info-dul {
   background-color: $brand-primary;
   color: white;
 
@@ -174,6 +174,36 @@
     border-color: shade($brand-primary, 50);
     background-color: shade($brand-primary, 50);
     color: tint($brand-primary, 80);
+  }
+}
+
+/* make alerts look more like m-callout */
+.alert-info {
+  background-color: white;
+  color: var(--color-neutral-400);
+
+  border-top: solid 1px var(--color-neutral-100);
+  border-right: solid 1px var(--color-neutral-100);
+  border-bottom: solid 1px var(--color-neutral-100);
+
+  border-left: solid 1px var(--color-teal-400);
+  padding: var(--space-medium) var(--space-large);
+  border-radius: 4px;
+  border-left-width: 4px;
+
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto 1fr auto;
+
+  p, a {
+    color: var(--color-neutral-400);
+  }
+
+  &::before {
+    display: block;
+    content: "\f05a";
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
   }
 }
 

--- a/app/assets/stylesheets/umich-arclight/_base.scss
+++ b/app/assets/stylesheets/umich-arclight/_base.scss
@@ -1,6 +1,10 @@
 /* ====================== */
 /* GLOBAL      */
 /* ====================== */
+html {
+  scroll-padding-top: 2rem;
+}
+
 body {
   background-color: #fff;
   accent-color: var(--color-teal-400);

--- a/app/assets/stylesheets/umich-arclight/_utilities.scss
+++ b/app/assets/stylesheets/umich-arclight/_utilities.scss
@@ -59,3 +59,15 @@ span.twitter-typeahead input[name="q"] {
 .al-search-result-index-article .row {
   padding-left: 4.5rem;
 }
+
+.reasonable-height {
+  min-height: 50vh;
+}
+
+.fs-3 {
+  font-size: 1.75rem !important;
+}
+
+.fs-4 {
+  font-size: 1.5rem !important;
+}

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,9 @@
+class ErrorsController < ApplicationController
+  def not_found
+    render status: :not_found
+  end
+
+  def internal_server_error
+    render status: :internal_server_error
+  end
+end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,19 @@
+<section class="mt-3 reasonable-height">
+  <h1>
+    <span class="badge badge-warning">500</span>
+    Application error
+  </h1>
+
+  <p class="fs-4 mt-3">
+    An error occurred in the application and your request
+    could not be served.
+  </p>
+
+  <p>
+    For urgent situations, please 
+    <strong><a href="mailto:dlps-help@umich.edu">report the problem</a></strong>.
+  </p>
+
+
+
+</section>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -5,12 +5,11 @@
   </h1>
 
   <p class="fs-4 mt-3">
-    An error occurred in the application and your request
-    could not be served.
+    What you've tried to reach isn't working.
   </p>
 
   <p>
-    For urgent situations, please 
+    Please 
     <strong><a href="mailto:dlps-help@umich.edu">report the problem</a></strong>.
   </p>
 

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,18 +1,19 @@
-<section class="mt-3 reasonable-height">
+<section class="mt-3 mb-3 reasonable-height">
   <h1>
-    <span class="badge badge-warning">500</span>
     Application error
   </h1>
 
   <p class="fs-4 mt-3">
-    What you've tried to reach isn't working.
+    What you've tried to reach isn't working. We'll need to investigate why.
   </p>
 
   <p>
     Please 
-    <strong><a href="mailto:dlps-help@umich.edu">report the problem</a></strong>.
+    <strong><a href="mailto:digital-collections-help@umich.edu">report the problem</a></strong>.
   </p>
 
-
+  <p>
+    Visit the <a href="/">Finding Aids Home</a> to start over or use the <a data-turbolinks="false" href="#q">collection search</a>.
+  </p>
 
 </section>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,28 @@
+<section class="mt-3 reasonable-height">
+  <h1>
+    <span class="badge badge-warning">404</span>
+    Page not found
+  </h1>
+
+  <p class="fs-4 mt-3">
+    Apologies, we cannot aid you in finding what you're looking for.
+    This can sometimes happen when:
+  </p>
+
+  <ul>
+    <li>The finding aid has been restructured</li>
+    <li>The page no longer exists</li>
+    <li>There's a slight typo in the web address</li>
+    <li>The web address wasn't copied fully</li>
+  </ul>
+
+  <p>
+    If you know what the page was supposed to be about, 
+    you can try <a data-toggle="modal" data-target="#advanced-search-modal" href="#">searching</a> the Finding Aids for an updated version.
+  </p>
+
+  <p>
+    You can also visit the <a href="/">Finding Aids Home</a>.
+  </p>
+
+</section>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,6 +1,5 @@
-<section class="mt-3 reasonable-height">
+<section class="mt-3 mb-3 reasonable-height">
   <h1>
-    <span class="badge badge-warning">404</span>
     Page not found
   </h1>
 
@@ -18,11 +17,11 @@
 
   <p>
     If you know what the page was supposed to be about, 
-    you can try <a data-toggle="modal" data-target="#advanced-search-modal" href="#">searching</a> the Finding Aids for an updated version.
+    you can try <a data-turbolinks="false" href="#q">searching</a> the Finding Aids for an updated version.
   </p>
 
   <p>
-    You can also visit the <a href="/">Finding Aids Home</a>.
+    Visit the <a href="/">Finding Aids homepage</a> to start over.
   </p>
 
 </section>

--- a/app/views/shared/_flash_msg.html.erb
+++ b/app/views/shared/_flash_msg.html.erb
@@ -1,0 +1,10 @@
+<% icon_map = { notice: 'info', error: 'critical', alert: 'warning' } %>
+<div class="flash_messages pt-3">
+  <% [:success, :notice, :error, :alert].each do |type| %>
+    <% if flash[type] %>
+      <m-callout icon="<%= icon_map.fetch(type, type) %>" dismissable>
+        <p><%= flash[type] %></p>
+      </m-callout>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -73,7 +73,7 @@
       <h2>Contact Us</h2>
       <ul>
         <li>
-          <a href="mailto:dlps-help@umich.edu">
+          <a href="mailto:digital-collections-help@umich.edu">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" role="img" focusable="false" aria-hidden="true" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
             <span>Report problems using this site</span></a>
         </li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module DulArclight
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.autoload_paths += %W[#{config.root}/lib]
+
+    # use custom error pages
+    config.exceptions_app = routes
+
     # # Settings in config/environments/* take precedence over those specified here.
     # # Application configuration can go into files in config/initializers
     # # -- all .rb files in that directory are automatically loaded after loading

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = !Rails.root.join("tmp/errors-dev.txt").exist?
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/locales/um_arclight.en.yml
+++ b/config/locales/um_arclight.en.yml
@@ -76,3 +76,8 @@ en:
       separatedmaterial: "Alternate Locations"
       relatedmaterial: "Related Materials"
       bibliography: "Bibliography"
+
+    errors:
+      redirected_to_collection: |
+        We’re not sure what section of the finding aid you were looking for;
+        you've been redirected to the collection main page.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,10 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get '/custom_sitemaps/:id', controller: 'custom_sitemaps', action: 'index', defaults: {format: 'xml'},
                               constraints: ->(request) { CUSTOM_SITEMAP_CONFIG.key?(request.params[:id]) }
 
+  ### Handle errors
+  match "/404", to: "errors#not_found", via: :all
+  match "/500", to: "errors#internal_server_error", via: :all
+
   mount Arclight::Engine => '/'
   mount BlacklightDynamicSitemap::Engine => '/'
   mount Blacklight::Engine => '/'

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,6 +1,6 @@
 namespace :dev do
   desc "Use custom error pages"
-  task :errors do
+  task errors: :environment do
     if File.exist?("tmp/errors-dev.txt")
       puts "Using default (development) error pages" if FileUtils.rm("tmp/errors-dev.txt")
     elsif FileUtils.touch("tmp/errors-dev.txt")

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,0 +1,10 @@
+namespace :dev do
+  desc "Use custom error pages"
+  task :errors do
+    if File.exist?("tmp/errors-dev.txt")
+      puts "Using default (development) error pages" if FileUtils.rm("tmp/errors-dev.txt")
+    elsif FileUtils.touch("tmp/errors-dev.txt")
+      puts "Using custom error pages"
+    end
+  end
+end


### PR DESCRIPTION
When we can't find the section but we've found a collection:
<img width="1205" alt="image" src="https://user-images.githubusercontent.com/537867/221944448-0efe8ac1-c6a0-4764-9096-e525388b2aa0.png">

True 404: 
<img width="1203" alt="image" src="https://user-images.githubusercontent.com/537867/221944266-09ebb910-01d0-47e6-8fd2-c992fbbec9ab.png">

500:
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/537867/221944342-71c9fe91-7ee7-423e-9cd5-245f1c4cc1b7.png">

To toggle the error handling in dev:

```
$ docker-compose exec -- app bundle exec rake dev:errors
```

To view these pages in dev:

* for the soft 404: open a collection, then modify the URL with `_xyzzy`
* for the 404: `http://localhost/catalog/xyzzy`
* for the 500: `docker-compose stop solr` and then reload the page
