### PR TITLE
docker-compose.yml tweak: map /Users/gkostin/github/gkostin1966/umich…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ volumes:
   data:
     driver_opts:
       type: none
-      device: ${PWD}/sample-ead
+      device: ${PWD}/data
       o: bind
   gems:
   db-data:


### PR DESCRIPTION
…-arclight/data to application data drive instead of /Users/gkostin/github/gkostin1966/umich-arclight/sample-ead which is the correct mapping since it picks up the xsd subdirectory which contains the EAD 2002 W3C Schema.