### PR TITLE
DCP2-481 - implement Clements inheritance algorithm

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -454,21 +454,31 @@ class CatalogController < ApplicationController
 
     # DUL CUSTOMIZATION: add creators field; it's missing in ArcLight core.
     config.add_component_field 'creators_ssim', label: 'Creator', link_to_facet: true, ignore_interesting: true
+
+    # UM CUSTOMIZATION: switch between containers vs. inherited containers as needed
     config.add_component_field 'containers', label: 'Containers', accessor: 'containers', separator_options: {
       words_connector: ', ',
       two_words_connector: ', ',
       last_word_connector: ', '
     }, if: lambda { |_context, _field_config, document|
-      document.containers.present?
+      document.containers.present? and !document.has_inherited_containers?
     }, ignore_interesting: true
-
-    config.add_component_field 'inherited_containers', label: 'Inherited Containers', accessor: 'inherited_containers', separator_options: {
+    config.add_component_field 'inherited_containers', label: 'Containers', accessor: 'inherited_containers', separator_options: {
       words_connector: ', ',
       two_words_connector: ', ',
       last_word_connector: ', '
     }, if: lambda { |_context, _field_config, document|
-      document.fetch('has_inherited_containers_ssi', 'false') == 'true'
+      document.has_inherited_containers?
     }, ignore_interesting: true
+
+    ## --- IN CASE OF NEEDING TO COMPARE INHERITED CONTAINERS
+    # config.add_component_field 'inherited_containers', label: 'Inherited Containers', accessor: 'inherited_containers', separator_options: {
+    #   words_connector: ', ',
+    #   two_words_connector: ', ',
+    #   last_word_connector: ', '
+    # }, if: lambda { |_context, _field_config, document|
+    #   document.fetch('has_inherited_containers_ssi', 'false') == 'true'
+    # }, ignore_interesting: true
 
     config.add_component_field 'abstract_tesim', label: 'Abstract', helper_method: :render_html_tags
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -461,6 +461,15 @@ class CatalogController < ApplicationController
     }, if: lambda { |_context, _field_config, document|
       document.containers.present?
     }, ignore_interesting: true
+
+    config.add_component_field 'inherited_containers', label: 'Inherited Containers', accessor: 'inherited_containers', separator_options: {
+      words_connector: ', ',
+      two_words_connector: ', ',
+      last_word_connector: ', '
+    }, if: lambda { |_context, _field_config, document|
+      document.fetch('has_inherited_containers_ssi', 'false') == 'true'
+    }, ignore_interesting: true
+
     config.add_component_field 'abstract_tesim', label: 'Abstract', helper_method: :render_html_tags
 
     # DUL CUSTOMIZATION: Present all physdesc as extent

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -101,6 +101,15 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
     end
   end
 
+  ### DCP2-482 FOR REVIEW
+  def inherited_containers
+    return [] if fetch('has_inherited_containers_ssi', 'false') == 'false'
+    fetch('inherited_containers_ssim', []).map do |container|
+      container[0] = container[0].capitalize
+      container
+    end
+  end
+
   # DUL override ArcLight core method; fall back to the ID if ref_ssm isn't present.
   # Currently only components get a ref_ssm.
   def reference

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -101,9 +101,13 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
     end
   end
 
-  ### DCP2-482 FOR REVIEW
+  ### Inheritred containers
+  def has_inherited_containers?
+    fetch('has_inherited_containers_ssi', 'false') == 'true'
+  end
+
   def inherited_containers
-    return [] if fetch('has_inherited_containers_ssi', 'false') == 'false'
+    return [] unless has_inherited_containers?
     fetch('inherited_containers_ssim', []).map do |container|
       container[0] = container[0].capitalize
       container

--- a/app/views/catalog/_containers.html.erb
+++ b/app/views/catalog/_containers.html.erb
@@ -2,8 +2,15 @@
 <%# Last checked for updates: ArcLight v0.3.2. %>
 <%# https://github.com/projectblacklight/arclight/blob/master/app/views/catalog/_containers.html.erb %>
 
-<%= content_tag('div', class: 'al-document-container col text-muted text-nowrap') do %>
+<%= content_tag('div', class: 'al-document-container col text-muted text-nowrap text-right') do %>
   <% if document.containers.present? && !online_contents_context? %>
     <%= document.containers.join(', ') %>
+  <% end %>
+  <% if document.fetch('has_inherited_components_ssi', 'false') == 'true' %>
+    <% unless document.containers.present? %>
+      <span>-</span>
+    <% end %>
+    <br />
+    <strong><%= document.fetch('inhertaible_containers_ssim').join(', ') %></strong>
   <% end %>
 <% end %>

--- a/app/views/catalog/_containers.html.erb
+++ b/app/views/catalog/_containers.html.erb
@@ -6,11 +6,11 @@
   <% if document.containers.present? && !online_contents_context? %>
     <%= document.containers.join(', ') %>
   <% end %>
-  <% if document.fetch('has_inherited_components_ssi', 'false') == 'true' %>
+  <% if document.fetch('has_inherited_containers_ssi', 'false') == 'true' %>
     <% unless document.containers.present? %>
       <span>-</span>
     <% end %>
     <br />
-    <strong><%= document.fetch('inhertaible_containers_ssim').join(', ') %></strong>
+    <strong><%= document.fetch('inherited_containers_ssim').join(', ') %></strong>
   <% end %>
 <% end %>

--- a/app/views/catalog/_containers.html.erb
+++ b/app/views/catalog/_containers.html.erb
@@ -3,14 +3,11 @@
 <%# https://github.com/projectblacklight/arclight/blob/master/app/views/catalog/_containers.html.erb %>
 
 <%= content_tag('div', class: 'al-document-container col text-muted text-nowrap text-right') do %>
-  <% if document.containers.present? && !online_contents_context? %>
-    <%= document.containers.join(', ') %>
-  <% end %>
-  <% if document.fetch('has_inherited_containers_ssi', 'false') == 'true' %>
-    <% unless document.containers.present? %>
-      <span>-</span>
+  <% unless online_contents_context? %>
+    <% if document.has_inherited_containers? %>
+      <%= document.inherited_containers.join(', ') %>
+    <% elsif document.containers.present? %>
+      <%= document.containers.join(', ') %>
     <% end %>
-    <br />
-    <strong><%= document.fetch('inherited_containers_ssim').join(', ') %></strong>
   <% end %>
 <% end %>

--- a/lib/dul_arclight/traject/ead2_config.rb
+++ b/lib/dul_arclight/traject/ead2_config.rb
@@ -862,7 +862,8 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
 
   to_field 'containers_ssim' do |record, accumulator|
     record.xpath('./did/container').each do |node|
-      accumulator << [node.attribute('type'), node.text].join(' ').strip
+      label = node['label'] || node['type'].capitalize
+      accumulator << [label, node.text].join(' ').strip
     end
   end
 


### PR DESCRIPTION
## Goal

This affects Clements EADS.

* container information should be carried forward when appropriate
* we’re calling it inheritance but it’s not quite: container information can be “inherited” from
    * ancestors
    * preceding siblings
    * descendants of the descendants of the preceding siblings of ancestors
* sometimes only part of a container hierarchy should be carried forward:
    * pages should inherit an earlier seen volume
    * folders should inherit an earlier seen box
* but not when the children have containers with volumes/boxes

## Part one: changes to indexing

`ead2_config.rb` adds an `inherited_containers_ssim` field where we collect container data that's been synthesized from the above algorithm. We use `INHERITABLE_CONTAINERS_REPOSITORIES` to determine which repositories get this field, and `INHERITABLE_TYPES` when encountering the appropriate "leaf" container type.

## Part two: changes to presentation

The view templates have been tweaked to display inherited containers when present _or_ present the stock containers.

## Testing/Browsing

Locally: index some Clements artifacts that take advantage of the inheritance algorithm (see the [ticket](https://mlit.atlassian.net/browse/DCP2-481) for more details):

* `nashd_final.xml`
* `jeffersont_final.xml`
* `langstroth_final.xml`

On preview:

* [Thomas Jefferson](https://preview.workshop.findingaids.lib.umich.edu/catalog/umich-wcl-M-230jef_al_4bf70b448ac8351a147acff1dd8b1c0b9a791980#contents)
* [Langstorth family papers](https://preview.workshop.findingaids.lib.umich.edu/catalog/umich-wcl-M-1898lang_al_4bf70b448ac8351a147acff1dd8b1c0b9a791980#contents)
* [Henry John Temple](https://preview.workshop.findingaids.lib.umich.edu/catalog/umich-wcl-M-1898lang_al_4bf70b448ac8351a147acff1dd8b1c0b9a791980#contents)
