### PR TITLE
DCP2-535 - stop truncating expanded entries

### DIFF
--- a/app/assets/javascripts/arclight/collection_navigation.js
+++ b/app/assets/javascripts/arclight/collection_navigation.js
@@ -63,8 +63,8 @@
           'f[parent_ssi][]': data.arclight.directparent,
           page: page,
           search_field: data.arclight.search_field,
-          view: data.arclight.view,
-          per_page: data.arclight.per_page
+          view: isNested ? `expanded_${data.arclight.view}` : data.arclight.view,
+          per_page: isNested ? data.arclight.childrencount : 100
         }
       }).done(function (response) {
         var resp = $.parseHTML(response);

--- a/app/assets/stylesheets/dul-arclight/modules/show_component.scss
+++ b/app/assets/stylesheets/dul-arclight/modules/show_component.scss
@@ -31,6 +31,8 @@
   }
   .al-document-extent {
     @include extent-badge;
+    display: block;
+    width: min-content;
     font-size: 0.75rem;
   }
 

--- a/app/assets/stylesheets/umich-arclight/_collections.scss
+++ b/app/assets/stylesheets/umich-arclight/_collections.scss
@@ -11,6 +11,10 @@ nav#about-collection-nav {
 
 #documents {
   margin-left: 3rem;
+
+  h3 {
+    margin-bottom: 0;
+  }
 }
 
 .indented {

--- a/app/assets/stylesheets/umich-arclight/_utilities.scss
+++ b/app/assets/stylesheets/umich-arclight/_utilities.scss
@@ -71,3 +71,8 @@ span.twitter-typeahead input[name="q"] {
 .fs-4 {
   font-size: 1.5rem !important;
 }
+
+.badge-info {
+  background-color: var(--color-teal-100);
+  color: black !important;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -592,6 +592,10 @@ class CatalogController < ApplicationController
     config.view.child_components
     config.view.child_components.display_control = false
     config.view.child_components.partials = %i[index_child_components_nestable]
+
+    config.view.expanded_child_components
+    config.view.expanded_child_components.display_control = false
+    config.view.expanded_child_components.partials = %i[index_child_components_nestable]
     # config.view.child_components.partials = %i[index_child_components]
 
     ##

--- a/app/models/concerns/dul_arclight/search_behavior.rb
+++ b/app/models/concerns/dul_arclight/search_behavior.rb
@@ -28,6 +28,7 @@ module DulArclight
     # For the collection_context views, set a higher (unlimited) maximum document return
     def add_hierarchy_max_rows(solr_params)
       solr_params[:rows] = 999_999_999 if %w[collection_context].include? blacklight_params[:view]
+      solr_params[:rows] = 999_999_999 if %w[expanded_child_components].include? blacklight_params[:view]
 
       # For inline child components display on component view, break into pages of 100.
       # This has to be in sync with collection_navigation.js

--- a/app/views/catalog/_containers.html.erb
+++ b/app/views/catalog/_containers.html.erb
@@ -2,7 +2,7 @@
 <%# Last checked for updates: ArcLight v0.3.2. %>
 <%# https://github.com/projectblacklight/arclight/blob/master/app/views/catalog/_containers.html.erb %>
 
-<%= content_tag('div', class: 'al-document-container col text-muted text-nowrap text-right') do %>
+<%= content_tag('div', class: 'al-document-container col text-nowrap badge badge-info') do %>
   <% unless online_contents_context? %>
     <% if document.has_inherited_containers? %>
       <%= document.inherited_containers.join(', ') %>
@@ -11,3 +11,4 @@
     <% end %>
   <% end %>
 <% end %>
+


### PR DESCRIPTION
Resolution: the context navigator (in the sidebar) does not paginate large lists, instead tweaking the solr request to request `999_999_999` rows. For now, use this approach for the nested contents.

Changes:

* `CatalogController`: configure an `expanded_child_components` view that's identical to the `child_components` view
* `collection_navigation.js`: use `expanded_child_components` for nested queries
* `DulArclight::add_hierarchy_max_rows`: set `solr_params[:rows]` to `999_999_999` for `expanded_child_components`, just like `collection_context`