### PR TITLE
DCP2-483 - Wrap automation around the ingest jobs

### DIFF
--- a/app/jobs/ingest_automation_job.rb
+++ b/app/jobs/ingest_automation_job.rb
@@ -1,0 +1,27 @@
+require_dependency "um_arclight/package/generator"
+
+class IngestAutomationJob < ApplicationJob
+  queue_as :automation
+
+  def perform(event, details)
+    case event
+    when 'ingest.file'
+      logger.info "Beginning Finding Aid ingest to repository '#{details[:repo_id]}' of EAD file #{details[:file_path]}"
+      ::IndexFindingAidJob.perform_later(details[:file_path], details[:repo_id])
+    when 'index.success'
+      logger.info "Finding Aid successfully indexed -- ID: #{details[:ead_id]}, source path: #{details[:src_path]}, archived path: #{details[:archive_path]}"
+      ::PackageFindingAidJob.perform_later(details[:ead_id], 'html')
+    when 'html.success'
+      logger.info "HTML generated for Finding Aid -- ID: #{details[:ead_id]}"
+      ::PackageFindingAidJob.perform_later(details[:ead_id], 'pdf')
+    when 'pdf.success'
+      logger.info "PDF generated for Finding Aid -- ID: #{details[:ead_id]}"
+      ::IngestAutomationJob.perform_later('ingest.success', ead_id: details[:ead_id])
+    when 'ingest.success'
+      logger.info "Ingest completed for Finding Aid -- ID: #{details[:ead_id]}"
+      # do some accounting
+    when 'index.failure', 'html.failure', 'pdf.failure'
+      logger.error "Ingest failed for Finding Aid -- event: #{event}, details: #{details.inspect}"
+    end
+  end
+end

--- a/app/jobs/package_finding_aid_job.rb
+++ b/app/jobs/package_finding_aid_job.rb
@@ -8,9 +8,18 @@ class PackageFindingAidJob < ApplicationJob
   queue_as :index
 
   def perform(identifier, format)
-    artifact = UmArclight::Package::Generator.new identifier: identifier
+    unless %w[html pdf].include?(format)
+      raise ::UmArclight::GenerateError, identifier, "Unsupported format requested: #{format}"
+    end
+    convert(identifier, format)
+  end
+
+  def convert(identifier, format)
+    artifact = ::UmArclight::Package::Generator.new identifier: identifier
     (format == 'html') ? artifact.generate_html : artifact.generate_pdf
+    ::IngestAutomationJob.perform_later "#{format}.success", ead_id: identifier
   rescue => error
-    raise UmArclight::GenerateError, identifier, error.to_s
+    ::IngestAutomationJob.perform_later "#{format}.failure", ead_id: identifier
+    raise ::UmArclight::GenerateError, identifier, error.to_s
   end
 end

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,1 @@
-"index,delete": 4
+"index,delete,automation": 4

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -1,0 +1,19 @@
+require 'arclight'
+require 'arclight/repository'
+
+namespace :arclight do
+  # FIXME: SHAMELESS copy of dul_arclight:reindex_everything for now
+  desc 'Reingest all finding aids in the data directory via background jobs'
+  task ingest_everything: :environment do
+    puts "Looking in #{DulArclight.finding_aid_data} ..."
+
+    # Find our configured repositories, get their IDs
+    repo_config.keys.each do |repo_id|
+      Dir.glob(File.join(DulArclight.finding_aid_data, 'ead', repo_id, '*.xml')) do |path|
+        IngestAutomationJob.perform_later('ingest.file', repo_id: repo_id, file_path: path)
+      end
+    end
+
+    puts 'All collections queued for Ingest.'
+  end
+end


### PR DESCRIPTION
This sequences the three main jobs (indexing, html generation, pdf generation) to consider a finding aid fully ingested/processed by using a fourth job for orchestration. It also adds a rake task to "ingest" everything rather than simply "reindex".

The event names/shapes/contracts are completely unchecked. This is stringly-typed, hash-oriented programming to add basic automation. The simplest thing that could possibly work, you might say.

There is some very strange stuff going on with the requires and autoloading of the lib directory. The setup with mixed require and require_dependency is certainly not correct, but it is working.