### PR TITLE
BUG FIX: exclude expanded_child_components from setting the preferred view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -589,11 +589,11 @@ class CatalogController < ApplicationController
     # DUL Customization for listing children of components
     # Child Components Index View
     # Modeled after Online Contents
-    config.view.child_components
+    config.view.child_components!
     config.view.child_components.display_control = false
     config.view.child_components.partials = %i[index_child_components_nestable]
 
-    config.view.expanded_child_components
+    config.view.expanded_child_components!
     config.view.expanded_child_components.display_control = false
     config.view.expanded_child_components.partials = %i[index_child_components_nestable]
     # config.view.child_components.partials = %i[index_child_components]

--- a/app/models/concerns/dul_arclight/catalog.rb
+++ b/app/models/concerns/dul_arclight/catalog.rb
@@ -129,7 +129,7 @@ module DulArclight
     # Overriding the Blacklight method so that hierarchy does not get stored as
     # the preferred view
     def store_preferred_view
-      return if %w[online_contents collection_context child_components].include?(params[:view])
+      return if %w[online_contents collection_context child_components expanded_child_components].include?(params[:view])
 
       super
     end


### PR DESCRIPTION
If `expanded_child_components` is not added to the exclusion list, that view gets used in search results to general confusion.