### PR TITLE
DCP2-545 - index container type separately from label

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -101,6 +101,10 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
     end
   end
 
+  def container_types
+    fetch('container_types_ssim', [])
+  end
+
   ### Inheritred containers
   def has_inherited_containers?
     fetch('has_inherited_containers_ssi', 'false') == 'true'
@@ -172,12 +176,12 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
 
   def is_checkbox_requestable? # rubocop:disable Naming/PredicateName
     config_present = repository_config.request_config_present_for_type?('aeon_hidden_form_request')
-    container_requestable = containers.all? do |container|
-      %w[Box Folder Reel Map-case Tube Object Volume Bundle].any? do |type|
-        container.match(/#{type}/)
+    container_requestable = container_types.all? do |container_type|
+      %w[box folder reel map-case tube object volume bundle].any? do |type|
+        container_type.casecmp(type) == 0
       end
     end
-    config_present && !containers.empty? && container_requestable
+    config_present && !container_types.empty? && container_requestable
   end
 
   def is_linkable?

--- a/lib/dul_arclight/traject/ead2_config.rb
+++ b/lib/dul_arclight/traject/ead2_config.rb
@@ -867,6 +867,12 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     end
   end
 
+  to_field 'container_types_ssim' do |record, accumulator|
+    record.xpath('./did/container[normalize-space(@type)]').each do |node|
+      accumulator << node['type']
+    end
+  end
+
   SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_tesim", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -153,4 +153,36 @@ RSpec.describe SolrDocument do
       expect(document.multiple_ddr_daos?).to be true
     end
   end
+
+  describe '#is_checkbox_requestable?' do
+    context 'with requestable types' do
+      let(:document) do
+        described_class.new(
+          container_types_ssim: [
+            'map-case'
+          ],
+          repository_ssm: ['University of Michigan Bentley Historical Library']
+        )
+      end
+
+      it 'returns true for map case' do
+        expect(document.is_checkbox_requestable?).to be true
+      end
+    end
+
+    context 'without requestable types' do
+      let(:document) do
+        described_class.new(
+          container_types_ssim: [
+            'thermos'
+          ],
+          repository_ssm: ['University of Michigan Bentley Historical Library']
+        )
+      end
+
+      it 'returns false for thermos' do
+        expect(document.is_checkbox_requestable?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
* track container type as data
* update `is_checkbox_requestable?` to use the data instaed of matching against the container label
