### PR TITLE
Dcp2 524/dcp2 264/finding aids preview

### DIFF
--- a/.docker/branch.dockerfile
+++ b/.docker/branch.dockerfile
@@ -13,8 +13,11 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends vim nodejs yarn
 
-RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN apt-get install -yqq --no-install-recommends ./google-chrome-stable_current_amd64.deb
+#RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+#RUN apt-get install -yqq --no-install-recommends ./google-chrome-stable_current_amd64.deb
+
+RUN wget -q https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_amd64.deb
+RUN apt-get install -yqq --no-install-recommends ./wkhtmltox_0.12.6.1-2.bullseye_amd64.deb
 
 ENV APP_PATH /opt/app
 RUN groupadd -g $GID -o $UNAME

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,7 @@ env:
   RAILS_ENV: "test"
   DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/umich-arclight-test"
   SOLR_URL: "http://127.0.0.1:8983/solr/umich-arclight-test"
+  FINDING_AID_DATA: "data"
 
 jobs:
   ci:

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 /sample-ead
 !/sample-ead/ead
 /spec/examples.txt
-/tmp
+**/tmp
 /vendor/bundle
 
 .byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,11 @@
 /log
 /node_modules
 /resque_web
+/sample-ead
+!/sample-ead/ead
 /spec/examples.txt
 /tmp
 /vendor/bundle
-
 
 .byebug_history
 .rspec_status

--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-lastUpdateCheck 1677171913260
+lastUpdateCheck 1680711584688

--- a/app/assets/javascripts/controller.js
+++ b/app/assets/javascripts/controller.js
@@ -1,0 +1,18 @@
+// This is a manifest file that'll be compiled into controller.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, or any plugin's
+// vendor/assets/javascripts directory can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// compiled file. JavaScript code in this file should be added after the last require_* statement.
+//
+// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// about supported directives.
+//
+//= require jquery3
+//= require rails-ujs
+//= require activestorage
+//= require turbolinks
+//= require bootstrap
+//

--- a/app/assets/javascripts/findingaids.js
+++ b/app/assets/javascripts/findingaids.js
@@ -1,0 +1,1 @@
+// findingaids.js supports findingaids request

--- a/app/assets/javascripts/slugmaps.js
+++ b/app/assets/javascripts/slugmaps.js
@@ -1,0 +1,1 @@
+// slugmaps.js supports slugmaps request

--- a/app/assets/stylesheets/controller.scss
+++ b/app/assets/stylesheets/controller.scss
@@ -1,0 +1,16 @@
+/*
+ * This is a manifest file that'll be compiled into controller.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
+ * vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add controller-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
+ * files in this directory. Styles in this file should be added after the last require_* statement.
+ * It is generally better to create a new file per style scope.
+ *
+ *= require scaffolds
+ *
+*/
+@import 'bootstrap';

--- a/app/assets/stylesheets/findingaids.scss
+++ b/app/assets/stylesheets/findingaids.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the findingaids controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #347bd7;
+
+  &:visited {
+    color: #41afd0;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #4e9adc;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/assets/stylesheets/slugmaps.scss
+++ b/app/assets/stylesheets/slugmaps.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the slugmaps controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/findingaids_controller.rb
+++ b/app/controllers/findingaids_controller.rb
@@ -1,0 +1,247 @@
+class FindingaidsController < ApplicationController
+  layout "controller"
+  before_action :set_findingaid, only: %i[show edit update destroy reindex]
+
+  # GET /findingaids or /findingaids.json
+  def index
+    Findingaid.where("updated_at < ?", 30.days.ago).each do |findingaid|
+      path = File.join(ENV["FINDING_AID_DATA"], "findingaids", findingaid.id.to_s)
+      FileUtils.rm(path) if File.exist?(path)
+      findingaid.destroy
+    end
+    @findingaids = Findingaid.order(updated_at: :desc)
+  end
+
+  # GET /findingaids/1 or /findingaids/1.json
+  def show
+  end
+
+  # GET /findingaids/new
+  def new
+    @findingaid = Findingaid.new
+  end
+
+  # GET /findingaids/1/edit
+  def edit
+  end
+
+  # POST /findingaids or /findingaids.json
+  def create
+    @findingaid = Findingaid.new
+
+    @findingaid.filename = ""
+    @findingaid.content = ""
+    @findingaid.size = 0
+    @findingaid.corpname = ""
+    @findingaid.reposlug = ""
+    @findingaid.eadid = ""
+    @findingaid.eadslug = ""
+    @findingaid.eadurl = ""
+    @findingaid.state = ""
+    @findingaid.error = ""
+
+    success = false
+    uploaded_file = findingaid_params[:content]
+
+    if uploaded_file
+      @findingaid.filename = uploaded_file.original_filename
+      @findingaid.content = uploaded_file.content_type
+      @findingaid.size = uploaded_file.size
+      @findingaid.state = "uploaded"
+      @findingaid.save!
+
+      path = File.join(ENV["FINDING_AID_DATA"], "findingaids", @findingaid.id.to_s)
+      FileUtils.mkdir_p(File.dirname(path))
+      FileUtils.copy_file(uploaded_file.path, path)
+
+      @findingaid.error = +""
+      doc = nil
+
+      # Parse Validation
+      begin
+        if @findingaid.error.blank?
+          doc = Nokogiri::XML(uploaded_file)
+          if doc.errors.present?
+            @findingaid.error = "Error XML parse: " + errors.join("<br>")
+            @findingaid.state = "errored"
+          end
+        end
+      rescue => e
+        @findingaid.error = "Exception XML parse: " + e.message
+        @findingaid.state = "errored"
+      end
+
+      # DTD Validation
+      begin
+        if @findingaid.error.blank?
+          Dir.chdir(Rails.root.join("data/ead2002")) # Directory where ead.dtd is stored locally.
+          options = Nokogiri::XML::ParseOptions::DEFAULT_XML | Nokogiri::XML::ParseOptions::DTDLOAD | Nokogiri::XML::ParseOptions::DTDVALID
+          uploaded_file.rewind
+          doc_with_dtd_loaded = Nokogiri::XML::Document.parse(uploaded_file, nil, nil, options)
+          errors = doc_with_dtd_loaded.external_subset&.validate(doc_with_dtd_loaded)
+          if errors.present?
+            @findingaid.error = "Error XML DTD validate: " + errors.join("<br>")
+            @findingaid.state = "errored"
+          end
+        end
+      rescue => e
+        @findingaid.error = "Exception XML DTD validate: " + e.message
+        @findingaid.state = "errored"
+      ensure
+        Dir.chdir(Rails.root)
+      end
+
+      # DTD to Schema Transform Validation
+      doc_with_xlink = nil
+      begin
+        if @findingaid.error.blank?
+          stylesheet = Nokogiri::XSLT.parse(Rails.root.join("data/ead2002/dtd2schema.xsl").read)
+          doc_with_xlink = stylesheet.transform(doc)
+          if doc_with_xlink.errors.present?
+            @findingaid.error = "Error XML transform: " + errors.join("<br>")
+            @findingaid.state = "errored"
+          end
+        end
+      rescue => e
+        @findingaid.error = "Exception XML transform: " + e.message
+        @findingaid.state = "errored"
+      end
+
+      # Schema Validation
+      begin
+        if @findingaid.error.blank?
+          schema = Nokogiri::XML::Schema(Rails.root.join("data/ead2002/ead2002.xsd").read, Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA & ~Nokogiri::XML::ParseOptions::NONET)
+          errors = schema.validate(doc_with_xlink)
+          if errors.present?
+            @findingaid.error = "Error XML schema validate: " + errors.join("; ")
+            @findingaid.state = "errored"
+          end
+        end
+      rescue => e
+        @findingaid.error = "Exception XML schema validate: " + e.message
+        @findingaid.state = "errored"
+      end
+
+      # rubocop:disable Lint/UselessAssignment
+      begin
+        if @findingaid.error.blank?
+          doc.remove_namespaces!
+
+          cmd = "@findingaid.eadid = doc.at_xpath('/ead/eadheader/eadid').text.strip"
+          @findingaid.eadid = doc.at_xpath('/ead/eadheader/eadid').text.strip
+
+          cmd = "@findingaid.eadslug = ead_slug(@findingaid.eadid)"
+          @findingaid.eadslug = ead_slug(@findingaid.eadid)
+
+          cmd = "@findingaid.corpname = doc.at_xpath('/ead/archdesc/did/repository/corpname').text.strip"
+          @findingaid.corpname = doc.at_xpath('/ead/archdesc/did/repository/corpname').text.strip
+
+          cmd = "@findingaid.reposlug = repo_slug(@findingaid.eadid, @findingaid.corpname)"
+          @findingaid.reposlug = repo_slug(@findingaid.eadid, @findingaid.corpname)
+        end
+      rescue => e
+        @findingaid.error = "Exception XML xpath #{cmd}: " + e.message
+        @findingaid.state = "errored"
+      end
+      # rubocop:enable Lint/UselessAssignment
+
+      success = @findingaid.save
+    else
+      @findingaid.errors.add(:content, "missing file")
+    end
+
+    respond_to do |format|
+      if success
+        format.html { redirect_to edit_findingaid_url(@findingaid), notice: "Finding aid was successfully uploaded." }  # rubocop:disable Rails/I18nLocaleTexts
+        format.json { render :show, status: :created, location: @findingaid }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @findingaid.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /findingaids/1 or /findingaids/1.json
+  def update
+    respond_to do |format|
+      if @findingaid.reposlug.blank? && findingaid_params[:reposlug].present?
+        slugmap = Slugmap.find_by(corpname: @findingaid.corpname)
+        if slugmap.present?
+          slugmap.update(reposlug: findingaid_params[:reposlug])
+        else
+          Slugmap.create(corpname: @findingaid.corpname, reposlug: findingaid_params[:reposlug])
+        end
+      end
+
+      if @findingaid.update(findingaid_params)
+        format.html { redirect_to findingaids_url }  # rubocop:disable Rails/I18nLocaleTexts
+        format.json { render :show, status: :ok, location: @findingaid }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @findingaid.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /findingaids/1 or /findingaids/1.json
+  def destroy
+    path = File.join(ENV["FINDING_AID_DATA"], "findingaids", @findingaid.id.to_s)
+    FileUtils.rm(path) if File.exist?(path)
+    @findingaid.destroy
+
+    respond_to do |format|
+      format.html { redirect_to findingaids_url, notice: "Finding aid was successfully destroyed." }  # rubocop:disable Rails/I18nLocaleTexts
+      format.json { head :no_content }
+    end
+  end
+
+  # PUT /findingaids/1/reindex
+  def reindex
+    IngestFindingAidJob.perform_later(@findingaid.id)
+    @findingaid.state = "queued"
+
+    respond_to do |format|
+      if @findingaid.save
+        format.html { redirect_to findingaid_url(@findingaid), notice: "Finding aid was successfully queued for ingest." } # rubocop:disable Rails/I18nLocaleTexts
+        format.json { render :show, status: :ok, location: @findingaid }
+      else
+        format.html { render :show, status: :unprocessable_entity }
+        format.json { render :show, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_findingaid
+    @findingaid = Findingaid.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def findingaid_params
+    params.require(:findingaid).permit(:filename, :content, :size, :corpname, :reposlug, :eadid, :eadslug, :eadurl, :state, :error)
+  end
+
+  def ead_slug(eadid)
+    eadid.tr(".", "-").to_s
+  end
+
+  def repo_slug(_eadid, corpname)
+    slugmap = Slugmap.find_by(corpname: corpname)
+    reposlug = slugmap&.reposlug || ""
+    Arclight::Repository.find_by(slug: reposlug)&.slug || ""
+  end
+
+  def fetch_doc(id)
+    params = {
+      fl: '*',
+      q: ["id:#{id}"],
+      start: 0,
+      rows: 1
+    }
+    repo = Blacklight.repository_class.new(CatalogController.new.helpers.blacklight_config)
+    response = repo.search(params)
+    response.documents.first
+  end
+end

--- a/app/controllers/slugmaps_controller.rb
+++ b/app/controllers/slugmaps_controller.rb
@@ -1,0 +1,72 @@
+class SlugmapsController < ApplicationController
+  layout "controller"
+  before_action :set_slugmap, only: %i[show edit update destroy]
+
+  # GET /slugmaps or /slugmaps.json
+  def index
+    @slugmaps = Slugmap.order(:reposlug, :corpname)
+  end
+
+  # GET /slugmaps/1 or /slugmaps/1.json
+  def show
+  end
+
+  # GET /slugmaps/new
+  def new
+    @slugmap = Slugmap.new
+  end
+
+  # GET /slugmaps/1/edit
+  def edit
+  end
+
+  # POST /slugmaps or /slugmaps.json
+  def create
+    @slugmap = Slugmap.new(slugmap_params)
+
+    respond_to do |format|
+      if @slugmap.save
+        format.html { redirect_to slugmap_url(@slugmap), notice: "Slugmap was successfully created." } # rubocop:disable Rails/I18nLocaleTexts
+        format.json { render :show, status: :created, location: @slugmap }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @slugmap.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /slugmaps/1 or /slugmaps/1.json
+  def update
+    respond_to do |format|
+      if @slugmap.update(slugmap_params)
+        format.html { redirect_to slugmap_url(@slugmap), notice: "Slugmap was successfully updated." } # rubocop:disable Rails/I18nLocaleTexts
+        format.json { render :show, status: :ok, location: @slugmap }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @slugmap.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /slugmaps/1 or /slugmaps/1.json
+  def destroy
+    @slugmap.destroy
+
+    respond_to do |format|
+      format.html { redirect_to slugmaps_url, notice: "Slugmap was successfully destroyed." } # rubocop:disable Rails/I18nLocaleTexts
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_slugmap
+    @slugmap = Slugmap.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def slugmap_params
+    params.require(:slugmap).permit(:corpname, :reposlug)
+  end
+end

--- a/app/jobs/index_finding_aid_job.rb
+++ b/app/jobs/index_finding_aid_job.rb
@@ -6,37 +6,50 @@ require_dependency "um_arclight/package/generator"
 class IndexFindingAidJob < ApplicationJob
   queue_as :index
 
-  def perform(path, repo_id)
-    env = { 'REPOSITORY_ID' => repo_id }
-    cmd = "bundle exec traject -u #{ENV.fetch('SOLR_URL', Blacklight.default_index.connection.base_uri).to_s.chomp('/')} -i xml -c ./lib/dul_arclight/traject/ead2_config.rb #{path}"
+  def perform(src_path, repo_id)
+    ead_id = nil
+    dest_path = nil
 
-    stdout_and_stderr, process_status = Open3.capture2e(env, cmd)
+    File.open(src_path, "r:UTF-8:UTF-8") do |file|
+      # A Traject reader which reads XML, and yields zero to many Nokogiri::XML::Document
+      # objects as source records in the traject pipeline. The default is to yield the _entire_ input XML
+      # as a single traject source record.
+      DulArclight::Traject::DulCompressedReader.new(file, {}).each do |doc|
+        indexer = Traject::Indexer::NokogiriIndexer.new(
+          # Keep things simple and not interfering with Rails
+          "processing_thread_pool" => 0, # disable Indexer processing thread pool
+          "solr_writer.thread_pool" => 0, # writing to solr is done inline, no threads
+          "solr_writer.batch_size" => 1, # send to solr for each record, no batching
+          "solr.url" => ENV.fetch("SOLR_URL", Blacklight.default_index.connection.base_uri).to_s.chomp("/"),
+          "repository" => repo_id
+        )
 
-    if process_status.success?
-      ead_id = eadid_slug(path)
-      dest_path = File.join(DulArclight.finding_aid_data, "xml", repo_id)
-      FileUtils.mkdir_p(dest_path)
-      dest = File.join(dest_path, "#{ead_id}.xml")
-      FileUtils.copy_file(path, dest, preserve: true, dereference: true, remove_destination: true)
-      puts stdout_and_stderr
-      ::IngestAutomationJob.perform_later('index.success', src_path: path, archive_path: dest, ead_id: ead_id)
-    else
-      ::IngestAutomationJob.perform_later('index.failure', src_path: path, archive_path: dest, ead_id: ead_id)
-      raise DulArclight::IndexError, stdout_and_stderr
+        # Note that keys passed in as an initializer arg will "override" any settings set with provide in config.
+        indexer.load_config_file(Rails.root.join("lib/dul_arclight/traject/ead2_config.rb"))
+
+        # #process_record takes a single source record, sends it thorough transformation,
+        # and sends the output the instance-configured writer. No logging, threading,
+        # or error handling is done for you. Skipped records will not be sent to writer.
+        # A Traject::Indexer::Context is returned from every call.
+        context = indexer.process_record(doc)
+
+        # You can (and may want/need to) manually call indexer.complete to run after_processing steps,
+        # and close/flush the writer. After calling complete, the indexer can not be re-used for more process_record calls,
+        # as the writer has been closed.
+        indexer.complete
+
+        # Make an archive copy of source file available for downloading.
+        ead_id = context.output_hash['id']&.first
+        dest_dir = File.join(DulArclight.finding_aid_data, "xml", repo_id)
+        dest_path = File.join(dest_dir, "#{ead_id}.xml")
+        FileUtils.mkdir_p(dest_dir)
+        FileUtils.copy_file(src_path, dest_path, preserve: true, dereference: true, remove_destination: true)
+
+        ::IngestAutomationJob.perform_later('index.success', src_path: src_path, archive_path: dest_path, ead_id: ead_id)
+      end
     end
-  end
-
-  private
-
-  def eadid_slug(path)
-    basename = File.basename(path, ".*")
-    eadid_slug = nil
-    File.open(path, "r:UTF-8:UTF-8") do |f|
-      doc = Nokogiri::XML(f)
-      doc.remove_namespaces!
-      eadid_node = doc.at_xpath('/ead/eadheader/eadid')
-      eadid_slug = eadid_node.text.strip.tr(".", "-").to_s if eadid_node && eadid_node.text.present?
-    end
-    eadid_slug || basename
+  rescue => e
+    ::IngestAutomationJob.perform_later('index.failure', src_path: src_path, archive_path: dest_path, ead_id: ead_id, err_msg: e.message)
+    raise DulArclight::IndexError, e.message
   end
 end

--- a/app/jobs/ingest_finding_aid_job.rb
+++ b/app/jobs/ingest_finding_aid_job.rb
@@ -1,0 +1,50 @@
+class IngestFindingAidJob < ApplicationJob
+  queue_as :index
+
+  def perform(id)
+    findingaid = Findingaid.find(id)
+    findingaid.state = "indexing"
+    findingaid.save!
+
+    begin
+      path = File.join(ENV["FINDING_AID_DATA"], "findingaids", findingaid.id.to_s)
+      logger.info "Beginning Finding Aid ingest to repository '#{findingaid.reposlug}' of EAD file #{path}"
+      IndexFindingAidJob.perform_now(path, findingaid.reposlug)
+    rescue => e
+      findingaid.error = "ERROR: IndexFindAidJob.perform_now(#{path}, #{findingaid.reposlug}) #{e.message}"
+      findingaid.state = "errored"
+    end
+
+    if findingaid.error.blank?
+      document = fetch_doc(findingaid.eadslug)
+      if document.present?
+        findingaid.eadurl = document['title_ssm']&.first
+        if findingaid.eadurl.present?
+          findingaid.state = "indexed"
+        else
+          findingaid.error = "ERROR: document['title_ssm']&.first is blank!"
+          findingaid.state = "errored"
+        end
+      else
+        findingaid.error = "ERROR: fetch_doc(#{findingaid.eadslug}) returned nil!"
+        findingaid.state = "errored"
+      end
+    end
+
+    findingaid.save!
+  end
+
+  private
+
+  def fetch_doc(id)
+    params = {
+      fl: '*',
+      q: ["id:#{id}"],
+      start: 0,
+      rows: 1
+    }
+    repo = Blacklight.repository_class.new(CatalogController.new.helpers.blacklight_config)
+    response = repo.search(params)
+    response.documents.first
+  end
+end

--- a/app/models/findingaid.rb
+++ b/app/models/findingaid.rb
@@ -1,0 +1,2 @@
+class Findingaid < ApplicationRecord
+end

--- a/app/models/slugmap.rb
+++ b/app/models/slugmap.rb
@@ -1,0 +1,2 @@
+class Slugmap < ApplicationRecord
+end

--- a/app/views/findingaids/_attributes.erb
+++ b/app/views/findingaids/_attributes.erb
@@ -1,0 +1,42 @@
+<div class="col-md-12">
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.reposlug") %> [ <%= findingaid.reposlug %> ]</div>
+    <div class="col-md-8"> <%= link_to_if findingaid.reposlug.present?, Arclight::Repository.find_by(slug: findingaid.reposlug)&.name,   repository_url(findingaid.reposlug)  %></div>
+  </div>
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.eadurl") %> [ <%= findingaid.eadslug %> ]</div>
+    <div class="col-md-8"><%= link_to_if findingaid.eadurl.present?, findingaid.eadurl,  solr_document_url(findingaid.eadslug) %></div>
+  </div>
+  <div class="row">
+    <div class="col-md-4">&nbsp;</div>
+    <div class="col-md-8">&nbsp;</div>
+  </div>
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.filename") %></div>
+    <div class="col-md-8">  <%= findingaid.filename %></div>
+  </div>
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.content") %></div>
+    <div class="col-md-8">  <%= findingaid.content %></div>
+  </div>
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.eadid") %></div>
+    <div class="col-md-8">  <%= findingaid.eadid %></div>
+  </div>
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.corpname") %></div>
+    <div class="col-md-8">  <%= findingaid.corpname %></div>
+  </div>
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.size") %></div>
+    <div class="col-md-8"><%= number_to_human_size(findingaid.size) %></div>
+  </div>
+  <div class="row">
+    <div class="col-md-4">&nbsp;</div>
+    <div class="col-md-8">&nbsp;</div>
+  </div>
+  <div class="row">
+    <div class="col-md-4"><%= I18n.t("helpers.label.findingaid.state") %></div>
+    <div class="col-md-8"><%= findingaid.state %> @ <%= findingaid.updated_at %></div>
+  </div>
+</div>

--- a/app/views/findingaids/_findingaid.json.jbuilder
+++ b/app/views/findingaids/_findingaid.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! findingaid, :id, :filename, :content, :size, :corpname, :reposlug, :eadid, :eadslug, :eadurl, :state, :error, :created_at, :updated_at
+json.url findingaid_url(findingaid, format: :json)

--- a/app/views/findingaids/_form.html.erb
+++ b/app/views/findingaids/_form.html.erb
@@ -1,0 +1,23 @@
+<div class="col-md-12">
+<%= form_with(model: findingaid, local: true) do |form| %>
+  <% if findingaid.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(findingaid.errors.count, "error") %> prohibited this findingaid from being saved:</h2>
+      <ul>
+      <% findingaid.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="row" class="field">
+    <div class="col-md-2"><%= form.label :reposlug %></div>
+    <div class="col-md-4"><%= form.collection_select :reposlug, Arclight::Repository.all.sort_by(&:name), :slug, :name, include_blank:true %></div>
+  </div>
+  <br>
+  <div class="row" class="actions">
+    <div class="col-md-2"></div>
+    <div class="col-md-4"><%= form.submit "Confirm" %></div>
+  </div>
+<% end %>
+</div>

--- a/app/views/findingaids/edit.html.erb
+++ b/app/views/findingaids/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="container">
+  <p id="notice"><%= notice %></p>
+  <% if @findingaid.error.blank? %>
+    <h1>Finding Aid Repository</h1>
+  <hr>
+  <%= render 'form', findingaid: @findingaid %>
+    <% else %>
+  <h1>Invalid Finding Aid</h1>
+    <% end %>
+  <hr>
+  <%= render 'attributes', findingaid: @findingaid %>
+  <hr>
+<!--  <%#= link_to 'Show', @findingaid %> |-->
+  <%= link_to 'Back', findingaids_path %>
+  <% if @findingaid.error.present? %>
+    <hr>
+    <p>
+      <strong>Error:</strong>
+      <%= @findingaid.error.html_safe %>
+    </p>
+    <hr>
+<!--    <%#= link_to 'Show', @findingaid %> |-->
+    <%= link_to 'Back', findingaids_path %>
+  <% end %>
+</div>

--- a/app/views/findingaids/index.html.erb
+++ b/app/views/findingaids/index.html.erb
@@ -1,0 +1,27 @@
+<div class="container">
+<p id="notice"><%= notice %></p>
+<h1>Finding Aids</h1>
+<%= link_to 'Upload Finding Aid', new_findingaid_path %>
+<% @findingaids.each do |findingaid| %>
+  <hr>
+  <div class="row">
+    <div class="col-md-11">
+      <%= render 'attributes', findingaid: findingaid %>
+    </div>
+    <div class="col-md-1">
+      <% reindex_flag = findingaid.reposlug.present? && findingaid.error.blank? && "uploaded".include?(findingaid.state) %>
+      <div><%= link_to_if reindex_flag, "Index", reindex_findingaid_path(findingaid), method: :put %></div>
+      <div>&nbsp;</div>
+      <% show_flag = findingaid.error.present? %>
+      <div><%= link_to_if show_flag, 'Show', findingaid %></div>
+      <div>&nbsp;</div>
+      <% edit_flag = (findingaid.state == "uploaded") %>
+      <div><%= link_to_if edit_flag, 'Edit', edit_findingaid_path(findingaid) %></div>
+      <div>&nbsp;</div>
+      <div><%= link_to 'Destroy', findingaid, method: :delete, data: { confirm: 'Are you sure?' } %></div>
+    </div>
+  </div>
+<% end %>
+<hr>
+<%= link_to 'Upload Finding Aid', new_findingaid_path %>
+</div>

--- a/app/views/findingaids/index.json.jbuilder
+++ b/app/views/findingaids/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @findingaids, partial: "findingaids/findingaid", as: :findingaid

--- a/app/views/findingaids/new.html.erb
+++ b/app/views/findingaids/new.html.erb
@@ -1,0 +1,25 @@
+<% findingaid = @findingaid %>
+<div class="container">
+  <h1>Upload Finding Aid</h1>
+  <%= form_with(model: findingaid, local: true) do |form| %>
+    <% if findingaid.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(findingaid.errors.count, "error") %> prohibited this findingaid from being saved:</h2>
+        <ul>
+          <% findingaid.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <%= form.hidden_field error: "no file" %>
+    <div class="row">&nbsp;</div>
+    <div class="row" class="field">
+      <div><%= form.file_field :content %></div>
+    </div>
+    <div class="row">&nbsp;</div>
+    <div class="row" class="actions">
+      <div><%= form.submit "Upload File" %></div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/findingaids/show.html.erb
+++ b/app/views/findingaids/show.html.erb
@@ -1,0 +1,25 @@
+<div class="container">
+  <p id="notice"><%= notice %></p>
+  <% if @findingaid.error.blank? %>
+
+<h1>Finding Aid</h1>
+    <% else %>
+    <h1>Invalid Finding Aid</h1>
+    <% end %>
+  <hr>
+  <%= render 'attributes', findingaid: @findingaid %>
+  <hr>
+  <%# edit_flag = (@findingaid.state == "uploaded") %>
+<!--  <%#= link_to_if edit_flag, 'Edit', edit_findingaid_path(@findingaid) %> |-->
+  <%= link_to 'Back', findingaids_path %>
+  <% if @findingaid.error.present? %>
+    <hr>
+    <p>
+      <strong>Error:</strong>
+      <%= @findingaid.error.html_safe %>
+    </p>
+    <hr>
+<!--    <%#= link_to_if edit_flag, 'Edit', edit_findingaid_path(@findingaid) %> |-->
+    <%= link_to 'Back', findingaids_path %>
+<% end %>
+</div>

--- a/app/views/findingaids/show.json.jbuilder
+++ b/app/views/findingaids/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "findingaids/findingaid", findingaid: @findingaid

--- a/app/views/layouts/controller.html.erb
+++ b/app/views/layouts/controller.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Finding Aids</title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+
+  <%= stylesheet_link_tag 'controller', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag 'controller', 'data-turbolinks-track': 'reload' %>
+
+  <%= stylesheet_link_tag params[:controller], 'data-turbolinks-track': 'reload'  %>
+  <%= javascript_include_tag params[:controller], 'data-turbolinks-track': 'reload' %>
+</head>
+
+<body>
+<%= yield %>
+</body>
+</html>

--- a/app/views/slugmaps/_form.html.erb
+++ b/app/views/slugmaps/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: slugmap, local: true) do |form| %>
+  <% if slugmap.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(slugmap.errors.count, "error") %> prohibited this slugmap from being saved:</h2>
+
+      <ul>
+      <% slugmap.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :corpname %>
+    <%= form.text_field :corpname %>
+  </div>
+
+  <div class="field">
+    <%= form.label :reposlug %>
+    <%= form.text_field :reposlug %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/slugmaps/_slugmap.json.jbuilder
+++ b/app/views/slugmaps/_slugmap.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! slugmap, :id, :corpname, :reposlug, :created_at, :updated_at
+json.url slugmap_url(slugmap, format: :json)

--- a/app/views/slugmaps/edit.html.erb
+++ b/app/views/slugmaps/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Slugmap</h1>
+
+<%= render 'form', slugmap: @slugmap %>
+
+<%= link_to 'Show', @slugmap %> |
+<%= link_to 'Back', slugmaps_path %>

--- a/app/views/slugmaps/index.html.erb
+++ b/app/views/slugmaps/index.html.erb
@@ -1,0 +1,21 @@
+<div class="container">
+<p id="notice"><%= notice %></p>
+<h1>Slug Maps</h1>
+  <b>
+    <hr>
+    <div class="row">
+      <div class="col-md-1"><%= I18n.t("helpers.label.slugmap.reposlug") %></div>
+      <div class="col-md-10"><%= I18n.t("helpers.label.slugmap.corpname") %></div>
+      <div class="col-md-1"></div>
+    </div>
+    <hr>
+  </b>
+  <% @slugmaps.each do |slugmap| %>
+    <div class="row">
+      <div class="col-md-1"><%= slugmap.reposlug %></div>
+      <div class="col-md-10"><%= slugmap.corpname %></div>
+      <div class="col-md-1"><%= link_to 'Destroy', slugmap, method: :delete, data: { confirm: 'Are you sure?' } %></div>
+    </div>
+    <hr>
+<% end %>
+</div>

--- a/app/views/slugmaps/index.json.jbuilder
+++ b/app/views/slugmaps/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @slugmaps, partial: "slugmaps/slugmap", as: :slugmap

--- a/app/views/slugmaps/new.html.erb
+++ b/app/views/slugmaps/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Slugmap</h1>
+
+<%= render 'form', slugmap: @slugmap %>
+
+<%= link_to 'Back', slugmaps_path %>

--- a/app/views/slugmaps/show.html.erb
+++ b/app/views/slugmaps/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Corpname:</strong>
+  <%= @slugmap.corpname %>
+</p>
+
+<p>
+  <strong>Reposlug:</strong>
+  <%= @slugmap.reposlug %>
+</p>
+
+<%= link_to 'Edit', edit_slugmap_path(@slugmap) %> |
+<%= link_to 'Back', slugmaps_path %>

--- a/app/views/slugmaps/show.json.jbuilder
+++ b/app/views/slugmaps/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "slugmaps/slugmap", slugmap: @slugmap

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w[print.css]
+Rails.application.config.assets.precompile += %w[controller.css controller.js findingaids.css findingaids.js print.css slugmaps.css slugmaps.js]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,20 @@
 
 en:
   hello: "Hello world"
+  helpers:
+    label:
+      findingaid:
+        content: 'content'
+        corpname: 'corpname'
+        eadid: 'eadid'
+        eadslug: "EAD Key"
+        eadurl: "Collection"
+        error: "Error"
+        filename: 'file'
+        reposlug: "Repository"
+        size: "size"
+        slug: 'Repository'
+        state: "Status"
+      slugmap:
+        corpname: "EAD corpname"
+        reposlug: "Slug"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,15 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     /[a-zA-Z0-9-]+/
   end
 
+  if ENV['FINDING_AID_INGEST'] == 'true'
+    resources :findingaids do
+      member do
+        put :reindex
+      end
+    end
+    resources :slugmaps, only: %i[index destroy]
+  end
+
   get 'help', to: 'help#help'
 
   resources :repositories, only: %i[index show], controller: 'arclight/repositories' do

--- a/db/migrate/20230217173119_create_findingaids.rb
+++ b/db/migrate/20230217173119_create_findingaids.rb
@@ -1,0 +1,18 @@
+class CreateFindingaids < ActiveRecord::Migration[5.2]
+  def change
+    create_table :findingaids do |t|
+      t.string :filename
+      t.string :content
+      t.integer :size
+      t.string :corpname
+      t.string :reposlug
+      t.string :eadid
+      t.string :eadslug
+      t.string :eadurl
+      t.string :state
+      t.string :error
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230228142056_create_slugmaps.rb
+++ b/db/migrate/20230228142056_create_slugmaps.rb
@@ -1,0 +1,10 @@
+class CreateSlugmaps < ActiveRecord::Migration[5.2]
+  def change
+    create_table :slugmaps do |t|
+      t.string :corpname
+      t.string :reposlug
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_07_134158) do
+ActiveRecord::Schema.define(version: 2023_02_28_142056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,21 @@ ActiveRecord::Schema.define(version: 2020_01_07_134158) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
+  create_table "findingaids", force: :cascade do |t|
+    t.string "filename"
+    t.string "content"
+    t.integer "size"
+    t.string "corpname"
+    t.string "reposlug"
+    t.string "eadid"
+    t.string "eadslug"
+    t.string "eadurl"
+    t.string "state"
+    t.string "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "searches", id: :serial, force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
@@ -34,6 +49,13 @@ ActiveRecord::Schema.define(version: 2020_01_07_134158) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_searches_on_user_id"
+  end
+
+  create_table "slugmaps", force: :cascade do |t|
+    t.string "corpname"
+    t.string "reposlug"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - "1234:1234" # RubyMine
       - "26162:26162" # RubyMine
     environment:
+      - FINDING_AID_INGEST=true
       - REDIS_URL=redis://redis:6379
     volumes:
       - .:/opt/app
@@ -26,7 +27,6 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
       - PGDATA=/var/lib/postgresql/data/db
-
     volumes:
       - db-data:/var/lib/postgresql/data
   solr:

--- a/spec/jobs/index_finding_aid_job_spec.rb
+++ b/spec/jobs/index_finding_aid_job_spec.rb
@@ -4,23 +4,40 @@ require 'rails_helper'
 RSpec.describe IndexFindingAidJob, type: :job do
   include ActiveJob::TestHelper
 
-  let(:file) { 'path/to/file.xml' }
-  let(:fd) { StringIO.open("<ead><eadheader><eadid>eadid.slug</eadid></eadheader></ead>") }
-  let(:repository_id) { 'repo' }
-  let(:path) { "#{DulArclight.finding_aid_data}/xml/#{repository_id}" }
-  let(:dest) { "#{path}/eadid-slug.xml" }
-  let(:stdout_and_stderr) { 'stdout and stderr' }
-  let(:process_status) { instance_double("Process::Status", "process_status", success?: success) }
-  let(:success) { true }
+  let(:src_path) { 'path/to/file.xml' }
+  let(:fd) { StringIO.open(xml) }
+  let(:xml) do
+    <<~EOS
+      <ead>
+        <eadheader>
+          #{eadid_tag}
+        </eadheader>
+          <archdesc level="1">
+            <did>
+              <unittitle>title</unittitle>
+            </did>
+          </archdesc>
+      </ead>
+    EOS
+  end
+  let(:eadid_tag) { "<eadid>#{eadid}</eadid>" }
+  let(:eadid) { "eadid.slug" }
+  let(:eadid_slug) { "eadid-slug" }
+  let(:repo_id) { 'repo' }
+  let(:repository) { class_double("Arclight::Repository", "repository", name: "repository") }
+  let(:dest_dir) { "#{DulArclight.finding_aid_data}/xml/#{repo_id}" }
+  let(:dest_path) { "#{dest_dir}/#{eadid_slug}.xml" }
+  let(:err_msg) { "Error Message" }
 
   before do
-    allow(Open3).to receive(:capture2e).with({"REPOSITORY_ID" => repository_id},
-                                             "bundle exec traject -u #{Blacklight.default_index.connection.base_uri.to_s.chomp("/")} -i xml -c ./lib/dul_arclight/traject/ead2_config.rb #{file}")
-      .and_return([stdout_and_stderr, process_status])
     allow(File).to receive(:open).and_call_original
-    allow(File).to receive(:open).with(file, "r:UTF-8:UTF-8").and_yield(fd)
-    allow(FileUtils).to receive(:mkdir_p).with(path)
-    allow(FileUtils).to receive(:copy_file).with(file, dest, {dereference: true, preserve: true, remove_destination: true})
+    allow(File).to receive(:open).with(src_path, "r:UTF-8:UTF-8").and_yield(fd)
+    allow(Arclight::Repository).to receive(:find_by).with(slug: repo_id).and_return(repository)
+    allow(FileUtils).to receive(:mkdir_p).with(dest_dir)
+    allow(FileUtils).to receive(:copy_file).with(src_path, dest_path, {dereference: true, preserve: true, remove_destination: true})
+    allow(IngestAutomationJob).to receive(:perform_later).and_call_original
+    allow(IngestAutomationJob).to receive(:perform_later).with('index.success', src_path: src_path, archive_path: dest_path, ead_id: eadid_slug)
+    allow(IngestAutomationJob).to receive(:perform_later).with('index.failure', src_path: src_path, archive_path: dest_path, ead_id: eadid_slug, err_msg: err_msg)
   end
 
   after do
@@ -29,52 +46,103 @@ RSpec.describe IndexFindingAidJob, type: :job do
   end
 
   it 'queues the job' do
-    expect { described_class.perform_later(file, repository_id) }.to have_enqueued_job(described_class).with(file, repository_id).on_queue("index")
+    expect { described_class.perform_later(src_path, repo_id) }.to have_enqueued_job(described_class).with(src_path, repo_id).on_queue("index")
   end
 
-  it 'puts stdout and stderr' do
-    expect { perform_enqueued_jobs { described_class.perform_later(file, repository_id) } }.to output(stdout_and_stderr + "\n").to_stdout_from_any_process
+  it 'performs the job' do
+    expect { perform_enqueued_jobs { described_class.perform_later(src_path, repo_id) } }.not_to raise_exception
+    expect(IngestAutomationJob).to have_received(:perform_later).with('index.success', src_path: src_path, archive_path: dest_path, ead_id: eadid_slug)
   end
 
-  it 'copies the source file to data xml repo directory using eadid slug' do
-    perform_enqueued_jobs { described_class.perform_later(file, repository_id) }
-    expect(FileUtils).to have_received(:mkdir_p).with(path)
-    expect(FileUtils).to have_received(:copy_file).with(file, dest, {dereference: true, preserve: true, remove_destination: true})
+  it 'copies the source file to data xml repo directory using ead id' do
+    perform_enqueued_jobs { described_class.perform_later(src_path, repo_id) }
+    expect(FileUtils).to have_received(:mkdir_p).with(dest_dir)
+    expect(FileUtils).to have_received(:copy_file).with(src_path, dest_path, {dereference: true, preserve: true, remove_destination: true})
   end
 
-  context 'when empty eadid tag' do
-    let(:fd) { StringIO.open("<ead><eadheader><eadid></eadid></eadheader></ead>") }
-    let(:dest) { "#{path}/#{File.basename(file, ".*")}.xml" }
+  context 'when eadid tag' do
+    let(:err_msg) { /Document is missing mandatory uniqueKey field: id/ }
 
-    it 'copies the source file to data xml repo directory using basename' do
-      perform_enqueued_jobs { described_class.perform_later(file, repository_id) }
-      expect(FileUtils).to have_received(:mkdir_p).with(path)
-      expect(FileUtils).to have_received(:copy_file).with(file, dest, {dereference: true, preserve: true, remove_destination: true})
+    context 'when value empty' do
+      let(:eadid) { "" }
+
+      it 'raises an exception' do
+        expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+        expect(IngestAutomationJob).to have_received(:perform_later).with('index.failure', src_path: src_path, archive_path: nil, ead_id: nil, err_msg: err_msg)
+      end
+
+      it 'does NOT copy source file to data xml repo directory' do
+        expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+        expect(FileUtils).not_to have_received(:mkdir_p).with(dest_path)
+        expect(FileUtils).not_to have_received(:copy_file).with(src_path, dest_path, {dereference: true, preserve: true, remove_destination: true})
+      end
+    end
+
+    context 'when tag missing' do
+      let(:eadid_tag) { "" }
+
+      it 'raises an exception' do
+        expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+        expect(IngestAutomationJob).to have_received(:perform_later).with('index.failure', src_path: src_path, archive_path: nil, ead_id: nil, err_msg: err_msg)
+      end
+
+      it 'does NOT copy source file to data xml repo directory' do
+        expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+        expect(FileUtils).not_to have_received(:mkdir_p).with(dest_path)
+        expect(FileUtils).not_to have_received(:copy_file).with(src_path, dest_path, {dereference: true, preserve: true, remove_destination: true})
+      end
     end
   end
 
-  context 'when missing eadid tag' do
-    let(:fd) { StringIO.open("<ead><eadheader></eadheader></ead>") }
-    let(:dest) { "#{path}/#{File.basename(file, ".*")}.xml" }
-
-    it 'copies the source file to data xml repo directory using basename' do
-      perform_enqueued_jobs { described_class.perform_later(file, repository_id) }
-      expect(FileUtils).to have_received(:mkdir_p).with(path)
-      expect(FileUtils).to have_received(:copy_file).with(file, dest, {dereference: true, preserve: true, remove_destination: true})
+  context 'when missing file' do
+    before do
+      allow(File).to receive(:open).with(src_path, "r:UTF-8:UTF-8").and_raise(StandardError, err_msg)
     end
-  end
-
-  context 'when traject failure' do
-    let(:success) { false }
 
     it 'raises an exception' do
-      expect { described_class.perform_now(file, repository_id) }.to raise_exception(DulArclight::IndexError, stdout_and_stderr)
+      expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+      expect(IngestAutomationJob).to have_received(:perform_later).with('index.failure', src_path: src_path, archive_path: nil, ead_id: nil, err_msg: err_msg)
     end
 
     it 'does NOT copy source file to data xml repo directory' do
-      expect { described_class.perform_now(file, repository_id) }.to raise_exception(DulArclight::IndexError, stdout_and_stderr)
-      expect(FileUtils).not_to have_received(:mkdir_p).with(path)
-      expect(FileUtils).not_to have_received(:copy_file).with(file, dest, {dereference: true, preserve: true, remove_destination: true})
+      expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+      expect(FileUtils).not_to have_received(:mkdir_p).with(dest_path)
+      expect(FileUtils).not_to have_received(:copy_file).with(src_path, dest_path, {dereference: true, preserve: true, remove_destination: true})
+    end
+  end
+
+  context 'when repo nil' do
+    let(:repo_id) { nil }
+    let(:err_msg) { /no implicit conversion of nil into String/ }
+
+    it 'raises an exception' do
+      expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+      expect(IngestAutomationJob).to have_received(:perform_later).with('index.failure', src_path: src_path, archive_path: nil, ead_id: eadid_slug, err_msg: err_msg)
+    end
+
+    it 'does NOT copy source file to data xml repo directory' do
+      expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+      expect(FileUtils).not_to have_received(:mkdir_p).with(dest_path)
+      expect(FileUtils).not_to have_received(:copy_file).with(src_path, dest_path, {dereference: true, preserve: true, remove_destination: true})
+    end
+  end
+
+  context 'when missing repo' do
+    let(:err_msg) { /undefined method `name' for nil:NilClass/ }
+
+    before do
+      allow(Arclight::Repository).to receive(:find_by).with(slug: repo_id).and_return(nil)
+    end
+
+    it 'raises an exception' do
+      expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+      expect(IngestAutomationJob).to have_received(:perform_later).with('index.failure', src_path: src_path, archive_path: nil, ead_id: nil, err_msg: err_msg)
+    end
+
+    it 'does NOT copy source file to data xml repo directory' do
+      expect { described_class.perform_now(src_path, repo_id) }.to raise_exception(DulArclight::IndexError, err_msg)
+      expect(FileUtils).not_to have_received(:mkdir_p).with(dest_path)
+      expect(FileUtils).not_to have_received(:copy_file).with(src_path, dest_path, {dereference: true, preserve: true, remove_destination: true})
     end
   end
 end

--- a/spec/jobs/ingest_finding_aid_job_spec.rb
+++ b/spec/jobs/ingest_finding_aid_job_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe IngestFindingAidJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:id) { 'id' }
+  let(:findingaid) { instance_double("Findingaid", "findingaid", id: 1, content: "", reposlug: "reposlug", eadslug: "eadslug", state: "uploaded", error: nil) }
+  let(:path) { File.join(ENV["FINDING_AID_DATA"], "findingaids", findingaid.id.to_s) }
+  let(:repository) { instance_double(Blacklight.repository_class, "repository") }
+  let(:catalog_controller) { instance_double("CatalogController", "catalog_controller", helpers: helpers) }
+  let(:helpers) { double("helpers", blacklight_config: "blacklight_config") } # rubocop:disable RSpec/VerifiedDoubles
+  let(:response) { instance_double("Blacklight::Solr::Response", "response", documents: [document]) }
+  let(:document) { instance_double("SolrDocument", "document") }
+
+  before do
+    allow(Findingaid).to receive(:find).with(id).and_return(findingaid)
+    allow(findingaid).to receive(:state=)
+    allow(findingaid).to receive(:save!).and_return(true)
+    allow(findingaid).to receive(:eadurl=)
+    allow(findingaid).to receive(:eadurl).and_return("title")
+    allow(IndexFindingAidJob).to receive(:perform_now).with(path, findingaid.reposlug).and_return(true)
+    allow(Blacklight.repository_class).to receive(:new).with("blacklight_config").and_return(repository)
+    allow(repository).to receive(:search).with({fl: "*", q: ["id:eadslug"], rows: 1, start: 0}).and_return(response)
+    allow(CatalogController).to receive(:new).and_return(catalog_controller)
+    allow(document).to receive(:[]).with("title_ssm").and_return(["title"])
+  end
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  it 'queues the job' do
+    expect { described_class.perform_later(id) }.to have_enqueued_job(described_class).with(id).on_queue("index")
+  end
+
+  it 'performs the job' do
+    expect { perform_enqueued_jobs { described_class.perform_later(id) } }.not_to raise_exception
+    expect(IndexFindingAidJob).to have_received(:perform_now).with(path, findingaid.reposlug)
+    expect(findingaid).to have_received(:state=).with("indexing")
+    expect(findingaid).to have_received(:eadurl=).with("title")
+    expect(findingaid).to have_received(:state=).with("indexed")
+    expect(findingaid).to have_received(:save!).twice
+  end
+
+  context 'when id not found' do
+    before { allow(Findingaid).to receive(:find).with(id).and_call_original }
+
+    it 'raises and exception' do
+      expect { described_class.perform_now(id) }.to raise_exception(ActiveRecord::RecordNotFound, "Couldn't find Findingaid with 'id'=#{id}")
+      expect(findingaid).not_to have_received(:state=).with("indexing")
+      expect(IndexFindingAidJob).not_to have_received(:perform_now).with(path, findingaid.reposlug)
+    end
+  end
+
+  context 'when index finding aid job fails' do
+    let(:error_message) { 'error message' }
+
+    before do
+      allow(IndexFindingAidJob).to receive(:perform_now).with(path, findingaid.reposlug).and_raise(error_message)
+      allow(findingaid).to receive(:error=)
+    end
+
+    it 'returns error with message' do
+      expect { described_class.perform_now(id) }.not_to raise_exception
+      expect(IndexFindingAidJob).to have_received(:perform_now).with(path, findingaid.reposlug)
+      expect(findingaid).to have_received(:state=).with("indexing")
+      expect(findingaid).to have_received(:error=).with("ERROR: IndexFindAidJob.perform_now(#{path}, #{findingaid.reposlug}) #{error_message}")
+      expect(findingaid).to have_received(:state=).with("errored")
+      expect(findingaid).to have_received(:save!).twice
+    end
+  end
+
+  context 'when repository search returns empty documents array' do
+    let(:response) { instance_double("Blacklight::Solr::Response", "response", documents: []) }
+
+    before do
+      allow(findingaid).to receive(:error=)
+    end
+
+    it 'returns error with message' do
+      expect { described_class.perform_now(id) }.not_to raise_exception
+      expect(IndexFindingAidJob).to have_received(:perform_now).with(path, findingaid.reposlug)
+      expect(findingaid).to have_received(:state=).with("indexing")
+      expect(findingaid).to have_received(:error=).with("ERROR: fetch_doc(#{findingaid.eadslug}) returned nil!")
+      expect(findingaid).to have_received(:state=).with("errored")
+      expect(findingaid).to have_received(:save!).twice
+    end
+  end
+
+  context 'when document title empty' do
+    before do
+      allow(document).to receive(:[]).with("title_ssm").and_return([""])
+      allow(findingaid).to receive(:eadurl).and_return("")
+      allow(findingaid).to receive(:error=)
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'returns error with message' do
+      expect { described_class.perform_now(id) }.not_to raise_exception
+      expect(IndexFindingAidJob).to have_received(:perform_now).with(path, findingaid.reposlug)
+      expect(findingaid).to have_received(:state=).with("indexing")
+      expect(findingaid).to have_received(:eadurl=).with("")
+      expect(findingaid).to have_received(:error=).with("ERROR: document['title_ssm']&.first is blank!")
+      expect(findingaid).to have_received(:state=).with("errored")
+      expect(findingaid).to have_received(:save!).twice
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/models/findingaid_spec.rb
+++ b/spec/models/findingaid_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Findingaid, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/slugmap_spec.rb
+++ b/spec/models/slugmap_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Slugmap, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
+ENV['FINDING_AID_INGEST'] ||= 'true'
 SPEC_ROOT = Pathname.new(__dir__)
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production

--- a/spec/routing/findingaids_routing_spec.rb
+++ b/spec/routing/findingaids_routing_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe FindingaidsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/findingaids").to route_to("findingaids#index")
+    end
+
+    it "routes to #new" do
+      expect(get: "/findingaids/new").to route_to("findingaids#new")
+    end
+
+    it "routes to #show" do
+      expect(get: "/findingaids/1").to route_to("findingaids#show", id: "1")
+    end
+
+    it "routes to #edit" do
+      expect(get: "/findingaids/1/edit").to route_to("findingaids#edit", id: "1")
+    end
+
+    it "routes to #create" do
+      expect(post: "/findingaids").to route_to("findingaids#create")
+    end
+
+    it "routes to #update via PUT" do
+      expect(put: "/findingaids/1").to route_to("findingaids#update", id: "1")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(patch: "/findingaids/1").to route_to("findingaids#update", id: "1")
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/findingaids/1").to route_to("findingaids#destroy", id: "1")
+    end
+
+    it "routes to #reindex via PUT" do
+      expect(put: "/findingaids/1/reindex").to route_to("findingaids#reindex", id: "1")
+    end
+  end
+end

--- a/spec/routing/slugmaps_routing_spec.rb
+++ b/spec/routing/slugmaps_routing_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe SlugmapsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/slugmaps").to route_to("slugmaps#index")
+    end
+
+    it "routes to #new", pending: "Implementation" do
+      expect(get: "/slugmaps/new").to route_to("slugmaps#new")
+    end
+
+    it "routes to #show", pending: "Implementation" do
+      expect(get: "/slugmaps/1").to route_to("slugmaps#show", id: "1")
+    end
+
+    it "routes to #edit", pending: "Implementation" do
+      expect(get: "/slugmaps/1/edit").to route_to("slugmaps#edit", id: "1")
+    end
+
+    it "routes to #create", pending: "Implementation" do
+      expect(post: "/slugmaps").to route_to("slugmaps#create")
+    end
+
+    it "routes to #update via PUT", pending: "Implementation" do
+      expect(put: "/slugmaps/1").to route_to("slugmaps#update", id: "1")
+    end
+
+    it "routes to #update via PATCH", pending: "Implementation" do
+      expect(patch: "/slugmaps/1").to route_to("slugmaps#update", id: "1")
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/slugmaps/1").to route_to("slugmaps#destroy", id: "1")
+    end
+  end
+end


### PR DESCRIPTION
`ENV['FINDING_AID_INGEST'] ||= 'true'` flag to enable /findingaids and /slugmaps routes.

IndexFindingAidJob refactored to use Traject API

IngestFindingAidJob wrapper around IndexFindingAidJob that records status in findingaids table.
