### PR TITLE
HOT FIX - use document.eadid when calculating aeon web urls

### DIFF
--- a/app/views/arclight/requests/_aeon_web_ead.html.erb
+++ b/app/views/arclight/requests/_aeon_web_ead.html.erb
@@ -1,6 +1,6 @@
 <% document ||= @document %>
 <% if UmArclight::DownloadHelper.new(document).ead_available? %>
-  <% ead_url = File.join(root_url, 'catalog', document.id.gsub('.', '-'), 'xml') %>
+  <% ead_url = File.join(root_url, 'catalog', document.eadid.gsub('.', '-'), 'xml') %>
   <% aeon_web_ead ||= Arclight::Requests::AeonWebEad.new(document, ead_url) %>
   <% aeon_web_ead_url = aeon_web_ead&.url %>
   <%= link_to 'Request', aeon_web_ead_url, class: 'btn btn-primary btn-sm', target:'_blank' %>


### PR DESCRIPTION
Always use the collection download URL, not the component.