### PR TITLE
ARC-82 - configure google tag manager (vs. the base analytics script)

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -25,9 +25,9 @@
     <meta name="google-site-verification" content="gSKpv970Qyib2XnLvLpjn0IhFmkeRhI1qNYbQNaQGHo" />
 
     <%# DUL CUSTOMIZATION: Google Analytics head tags %>
-    <% if DulArclight.google_analytics_tracking_id.present? %>
-      <%= render partial: "shared/google_analytics_head", locals: {
-        ga_tracking_id: DulArclight.google_analytics_tracking_id } %>
+    <% if UmArclight.google_tag_manager_id.present? %>
+      <%= render partial: "shared/google_tag_manager_head", locals: {
+        ga_tag_manager_id: UmArclight.google_tag_manager_id } %>
     <% end %>
 
     <%# DUL CUSTOMIZATION: Open Graph & Twitter card metadata %>
@@ -35,9 +35,9 @@
     <meta property="og:title" content="<%= render_page_title %>"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
-      <link href="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/umich-lib.css" rel="stylesheet"/>
-      <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/dist/umich-lib/umich-lib.esm.js"></script>
-      <script nomodule src="https://cdn.jsdelivr.net/npm/@umich-lib/components@1.1.0/dist/umich-lib/umich-lib.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/umich-lib.css" rel="stylesheet"/>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/dist/umich-lib/umich-lib.esm.js"></script>
+    <script nomodule src="https://cdn.jsdelivr.net/npm/@umich-lib/components@1.1.0/dist/umich-lib/umich-lib.js"></script>
 
   </head>
   <body class="<%= render_body_class %>">
@@ -76,10 +76,5 @@
 
     <%= render 'catalog/search_form_advanced_modal.html.erb' %>
 
-    <%# DUL CUSTOMIZATION: Google Analytics end-body tags %>
-    <% if DulArclight.google_analytics_tracking_id.present? %>
-      <%= render partial: "shared/google_analytics_body", locals: {
-        ga_tracking_id: DulArclight.google_analytics_tracking_id } %>
-    <% end %>
   </body>
 </html>

--- a/app/views/shared/_google_tag_manager_head.html.erb
+++ b/app/views/shared/_google_tag_manager_head.html.erb
@@ -1,0 +1,42 @@
+<script>
+  // add the user_properties the app collects as data attributes on 
+  // document.documentElement for later use in GTM
+  var user_properties = <%= ga_user_properties %>
+  if ( user_properties['page_type'] == 'Search Results Page' ) {
+    if ( user_properties['repository_id'] === undefined ) {
+      let repositorySet = new Set;
+      $("[data-repository-id]").each(function(idx, div) {
+        if ( div.dataset.repositoryId ) {
+          repositorySet.add(div.dataset.repositoryId);
+        }
+      })
+      if ( repositorySet.size > 0 ) {
+        user_properties['repository_id'] = ':' + Array.from(repositorySet).sort().join(':') + ':';
+      }
+    }
+    if ( user_properties['collection_id'] === undefined && location.search.indexOf('collection_sim') > -1 ) {
+      let collectionSet = new Set;
+      // collect the first link of available breadcrumbs
+      $("article[data-document-id] .breadcrumb-links").find("a:first-child").each(function(idx, link) {
+        let collectionId = (link.getAttribute('href').split('/')).pop();
+        collectionSet.add(collectionId);
+      })
+      if ( collectionSet.size == 1 ) {
+        // if there's only one collectionId, we are probably searching within a collection
+        user_properties['collection_id'] = ':' + Array.from(collectionSet).join(':') + ':';
+      }
+    }
+  }
+  Object.keys(user_properties).forEach((key) => {
+    // keys will be document.documentElement.dataset.gtm_collection_id
+    document.documentElement.setAttribute(`data-gtm_${key}`, user_properties[key]);
+  })
+</script>
+
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<%= ga_tag_manager_id %>');</script>
+<!-- End Google Tag Manager -->

--- a/config/initializers/um_arclight.rb
+++ b/config/initializers/um_arclight.rb
@@ -1,0 +1,2 @@
+require 'um_arclight'
+STDERR.puts "AHOY AHOY WUT?"

--- a/config/initializers/um_arclight.rb
+++ b/config/initializers/um_arclight.rb
@@ -1,2 +1,1 @@
 require 'um_arclight'
-STDERR.puts "AHOY AHOY WUT?"

--- a/lib/um_arclight.rb
+++ b/lib/um_arclight.rb
@@ -1,0 +1,5 @@
+module UmArclight
+  mattr_accessor :google_tag_manager_id do
+    ENV['GOOGLE_TAG_MANAGER_ID']
+  end
+end


### PR DESCRIPTION
Updates:

* removes google analytics partials from `base.html.erb`
* loads `shared/google_tag_manager_head` if `UmArclight.google_tag_manager_id` has been set
* introduces `UmArclight` module to stop using `DulArclight` for this stuff
* requires `GOOGLE_TAG_MANAGER_ID` to be set in the environment