### PR TITLE
ARC-78 Move show buttons under Contents

### DIFF
--- a/app/assets/stylesheets/umich-arclight/_results.scss
+++ b/app/assets/stylesheets/umich-arclight/_results.scss
@@ -6,7 +6,7 @@
 }
 
 #content #documents {
-  margin-bottom: 4rem;
+  margin-bottom: 2rem;
 }
 
 .al-repositories {
@@ -69,4 +69,12 @@
       clip: unset !important;
     }
   }
+}
+
+/* Show Contents Child Components */
+
+.documents-child_components {
+  position: relative;
+  height: calc(100vh/2);
+  overflow-y: scroll;
 }

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -250,9 +250,17 @@
   <%# Child Components           %>
   <%# ========================== %>
 
+  <div class="contents-wrapper">
   <h2 class="al-show-sub-heading" id="<%= t("arclight.views.show.sections.contents").parameterize %>">
     <%= t("arclight.views.show.sections.contents") %>
   </h2>
+  <div class="d-flex mt-3 mb-3">
+    <div class="flex-fill">
+      <%= render partial: 'arclight/requests', locals: { document: document } %>
+    </div>
+   </div>
+  </div>
+  
   <%= document.non_component_contents %>
   <% if document.children? %>
     <%= content_tag(


### PR DESCRIPTION
## What's New
(Draft)

In response to:
[ARC-78](https://mlit.atlassian.net/browse/ARC-78)

### Problem
Request and Request/clear buttons are "hidden" in mobile view under a collapsed menu. We want to make this more visible to users in all viewport sizes.

### Proposed Solution
Copy the show actions for Request/clear under the Contents container. Also make the results under Contents scrollable to keep show buttons in view.

Outstanding questions:
- Keep show-actions under The Collection side menu as well? This means the user would have access even when there is no Contents container on child pages.
- Show or remove number items selected next to Clear button (when available)