### PR TITLE
Support Solr 9 with LatLonPointSpatialField

### DIFF
--- a/solr/arclight/conf/schema.xml
+++ b/solr/arclight/conf/schema.xml
@@ -266,7 +266,7 @@
     </fieldType>
 
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+    <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
 
     <fieldType name="_nest_path_" class="solr.NestPathField" />
 


### PR DESCRIPTION
The LatLonType was deprecated and replaced by LatLonPointSpatialField. The former was removed in Solr 9. This change retains compatibility for Solr 8 while suporting 9.