### PR TITLE
A11y fixes from Siteimprove scan

### DIFF
--- a/app/assets/javascripts/accessibility-patches.js
+++ b/app/assets/javascripts/accessibility-patches.js
@@ -38,6 +38,27 @@ function applyAccessibilityPatches() {
   
   $('nav[role="region"]').attr('role', 'navigation');
 
+  /* Issue: aria-label is not permitted on a non-interactive <span>. The active   */
+  /* page indicator uses <span class="page-link" aria-label="Current Page, Page N"*/
+  /* aria-current="true">; aria-current="true" is sufficient. */
+  /* Platform: Blacklight */
+  /* Version fixed in: (not fixed) */
+
+  $('li.page-item.active span.page-link').removeAttr('aria-label');
+
+  /* ---------------------------------- */
+  /* Area: Facet panel collapse divs    */
+  /* ---------------------------------- */
+  /* Issue: aria-labelledby is not a supported property on a plain <div> (implicit  */
+  /* role "generic"). Siteimprove flags this as "Use supported states and properties */
+  /* only." Adding role="group" makes aria-labelledby valid and is semantically      */
+  /* appropriate for a collapsible facet panel labelled by its heading.              */
+  /* Platform: Blacklight */
+  /* Version fixed in: (not fixed) */
+  /* https://github.com/projectblacklight/blacklight/blob/master/app/components/blacklight/facet_field_component.html.erb */
+
+  $('div.facet-content[aria-labelledby]').attr('role', 'group');
+
 
   /* ---------------------------------- */
   /* Area: Bookmark Checkboxes          */

--- a/app/assets/stylesheets/dul-arclight/dul_styles.scss
+++ b/app/assets/stylesheets/dul-arclight/dul_styles.scss
@@ -130,10 +130,11 @@ a {
 
 .al-search-breadcrumb {
   font-size: 16px;
-  color: $gray-light;
+  color: #212B36
+;
 
   span {
-    color: $gray-light-more;
+    color:  #212B36;
     padding-right: 0.25rem;
     padding-left: 0.25rem;
   }
@@ -463,7 +464,7 @@ a {
     display: inline-block;
 
     &:hover {
-      color: $primary-link-color;
+      color: #1D7491;
       text-decoration: underline;
     }
   }
@@ -527,17 +528,18 @@ a {
 
   a.al-toggle-view-children {
     opacity: 1;
-    background-color: $primary-link-color-inverted;
-    filter: invert(100%);
+    background-color: #E9F2F5;
+    border: solid 1px #1D7491;
     border-radius: 50%;
     display: inline-block;
   }
 }
 
 .al-toggle-view-children {
-  width: 1rem;
-  height: 1rem;
+  width: 1.25rem;
+  height: 1.25rem;
   margin-top: 4px;
+  margin-right: .25rem;
 }
 
 .al-collection-context-collapsible .al-toggle-view-children {

--- a/app/assets/stylesheets/dul-arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/dul-arclight/modules/context_navigation.scss
@@ -48,7 +48,7 @@
       }
       background-image: image-url('blacklight/plus.svg');
       background-repeat: no-repeat;
-      background-size: 1rem;
+      background-size: 1.05rem;
       background-position: center;
       &:not(.collapsed) {
         background-image: image-url('blacklight/minus.svg');
@@ -56,7 +56,6 @@
     }
 
     .al-toggle-view-children .blacklight-icons svg {
-      fill: black; /* gets inverted */
       vertical-align: top;
     }
     .document-title-heading {
@@ -87,7 +86,8 @@
       text-align: left;
       text-transform: lowercase;
       padding-left: 2.25rem;
-      background-color: #999;
+      color: #fff;
+      background-color: #1D7491;
       border: none;
       background-repeat: no-repeat;
       background-size: 1rem auto;

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -173,7 +173,6 @@
       <p>Some materials from this collection are available online</p>
         <%= link_to search_action_path(f: { has_online_content_ssim: ["online"], repository_sim: [document.repository], collection_sim: [document.collection_name] }),
                             class: "callout--link",
-                            aria: { label: 'limit to components with online access' },
                             data: { ga_label: 'filter to online access' } do %>
             <span class="fas fa-filter"></span> Only view items with digital materials
           <% end %>


### PR DESCRIPTION
# What's New - Accessibility & UI Improvements

This PR fixes a small number of accessibility issues found through the most recent Siteimprove automated accessibility scanning. Remediation of these issues is required in April 2026. Changes organized by files below:

## accessibility-patches.js
- **Pagination active page span:** Removes `aria-label` from the non-interactive `<span class="page-link">` on the active pagination item. `aria-current="true"` is sufficient; `aria-label` is not permitted on non-interactive elements.
- **Facet panel collapse divs:** Adds `role="group"` to `.facet-content` divs that have `aria-labelledby`. Without an explicit role, `aria-labelledby` is not a valid property on a generic `<div>` (Siteimprove: "Use supported states and properties only.").

## _show_default.html.erb
- Removes `aria: { label: 'limit to components with online access' }` from the "Only view items with digital materials" link, where the programmatic label did not match the visible link text.

## `dul_styles.scss`
- Updates breadcrumb text colors from `$gray-light` / `$gray-light-more` variables to explicit hex values (`#212B36`) for improved contrast.
- Replaces CSS `filter: invert(100%)` on the expand/collapse toggle with explicit background (`#E9F2F5`) and border (`#1D7491`) styling; increases toggle size from `1rem` to `1.25rem` and adds right margin. Toggles must meet a certain size so they can be activated.

## `context_navigation.scss`
- Adjusts toggle icon background size from `1rem` to `1.05rem`.
- Removes `fill: black` from the toggle SVG icon (no longer needed without the invert filter).
- Updates the "load more" button: changes background from `#999` to `#1D7491` (brand teal) and adds `color: #fff` for legible contrast.